### PR TITLE
Created persistent event listeners

### DIFF
--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -19,7 +19,10 @@ namespace OneIdentity.SafeguardDotNet.A2A
 
         /// <summary>
         /// Gets an A2A event listener. The handler passed in will be registered for the AssetAccountPasswordUpdated
-        /// event, which is the only one supported in A2A. You just have to call Start().
+        /// event, which is the only one supported in A2A. You just have to call Start(). The event listener returned
+        /// by this method will not automatically recover from a SignalR timeout which occurs when there is a 30+
+        /// second outage. To get an event listener that supports recovering from longer term outages, please use
+        /// Safeguard.Event to request a persistent event listener.
         /// </summary>
         /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
         /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>

--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security;
+using OneIdentity.SafeguardDotNet.Event;
 
 namespace OneIdentity.SafeguardDotNet.A2A
 {

--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security;
 
-namespace OneIdentity.SafeguardDotNet
+namespace OneIdentity.SafeguardDotNet.A2A
 {
     /// <summary>
     /// This is a reusable interface for calling Safeguard A2A without having to continually

--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -22,7 +22,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
         /// event, which is the only one supported in A2A. You just have to call Start(). The event listener returned
         /// by this method will not automatically recover from a SignalR timeout which occurs when there is a 30+
         /// second outage. To get an event listener that supports recovering from longer term outages, please use
-        /// Safeguard.Event to request a persistent event listener.
+        /// Safeguard.A2A.Event to request a persistent event listener.
         /// </summary>
         /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
         /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>

--- a/SafeguardDotNet/A2A/SafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/SafeguardA2AContext.cs
@@ -2,6 +2,7 @@
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Newtonsoft.Json.Linq;
+using OneIdentity.SafeguardDotNet.Event;
 using RestSharp;
 using Serilog;
 

--- a/SafeguardDotNet/A2A/SafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/SafeguardA2AContext.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 using RestSharp;
 using Serilog;
 
-namespace OneIdentity.SafeguardDotNet
+namespace OneIdentity.SafeguardDotNet.A2A
 {
     internal class SafeguardA2AContext : ISafeguardA2AContext
     {

--- a/SafeguardDotNet/Event/EventHandlerRegistry.cs
+++ b/SafeguardDotNet/Event/EventHandlerRegistry.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Serilog;
+
+namespace OneIdentity.SafeguardDotNet.Event
+{
+    using DelegateRegistry = Dictionary<string, List<SafeguardEventHandler>>;
+
+    internal class EventHandlerRegistry
+    {
+        private readonly DelegateRegistry _delegateRegistry =
+            new DelegateRegistry(StringComparer.InvariantCultureIgnoreCase);
+
+        private void HandleEvent(string eventName, string eventBody)
+        {
+            if (!_delegateRegistry.ContainsKey(eventName))
+            {
+                Log.Information("No handlers registered for event {Event}", eventName);
+                return;
+            }
+
+            if (_delegateRegistry.ContainsKey(eventName))
+            {
+                foreach (var handler in _delegateRegistry[eventName])
+                {
+                    Log.Information("Calling {Delegate} for event {Event}", handler.Method.Name, eventName);
+                    Log.Debug("Event {Event} has body {EventBody}", eventName, eventBody);
+                    Task.Run(() =>
+                    {
+                        try
+                        {
+                            handler(eventName, eventBody);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "An error occured while calling {Delegate}", handler.Method.Name);
+                        }
+                    });
+                }
+            }
+        }
+
+        private (string, JToken)[] ParseEvents(string eventObject)
+        {
+            try
+            {
+                var events = new List<(string, JToken)>();
+                var jObject = JObject.Parse(eventObject);
+                var jEvents = jObject["A"];
+                foreach (var jEvent in jEvents)
+                {
+                    var name = jEvent["Name"];
+                    var body = jEvent["Data"];
+                    // Work around for bug in A2A events in Safeguard 2.2 and 2.3
+                    if (name != null && int.TryParse(name.ToString(), out _))
+                        name = body["EventName"];
+                    events.Add((name?.ToString(), body));
+                }
+                return events.ToArray();
+            }
+            catch (Exception)
+            {
+                Log.Warning("Unable to parse event object {EventObject}", eventObject);
+                return null;
+            }
+        }
+
+        public void HandleEvent(string eventObject)
+        {
+            var events = ParseEvents(eventObject);
+            if (events == null)
+                return;
+            foreach (var eventInfo in events)
+            {
+                if (eventInfo.Item1 == null)
+                {
+                    Log.Warning("Found null event with body {EventBody}", eventInfo.Item2);
+                    continue;
+                }
+                HandleEvent(eventInfo.Item1, eventInfo.Item2.ToString());
+            }
+        }
+
+        public void RegisterEventHandler(string eventName, SafeguardEventHandler handler)
+        {
+            if (!_delegateRegistry.ContainsKey(eventName))
+                _delegateRegistry[eventName] = new List<SafeguardEventHandler>();
+            _delegateRegistry[eventName].Add(handler);
+            Log.Information("Registered event {Event} with delegate {Delegate}", eventName, handler.Method.Name);
+        }
+    }
+}

--- a/SafeguardDotNet/Event/EventHandlerRegistry.cs
+++ b/SafeguardDotNet/Event/EventHandlerRegistry.cs
@@ -88,7 +88,7 @@ namespace OneIdentity.SafeguardDotNet.Event
             if (!_delegateRegistry.ContainsKey(eventName))
                 _delegateRegistry[eventName] = new List<SafeguardEventHandler>();
             _delegateRegistry[eventName].Add(handler);
-            Log.Information("Registered event {Event} with delegate {Delegate}", eventName, handler.Method.Name);
+            Log.Debug("Registered event {Event} with delegate {Delegate}", eventName, handler.Method.Name);
         }
     }
 }

--- a/SafeguardDotNet/Event/ISafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/ISafeguardEventListener.cs
@@ -2,12 +2,19 @@
 
 namespace OneIdentity.SafeguardDotNet.Event
 {
+    /// <summary>
+    /// A callback that will be called when a given event occurs in Safeguard. The callback will
+    /// receive the event name and JSON data representing the event.
+    /// </summary>
+    /// <param name="eventName">Name of the event.</param>
+    /// <param name="eventBody">JSON string containing event data.</param>
     public delegate void SafeguardEventHandler(string eventName, string eventBody);
 
     /// <summary>
     /// This is an event listener interface that will allow you to be notified each time something
     /// changes on Safeguard. The events that you are notified for depend on the role and event
-    /// registrations of the authenticated user.
+    /// registrations of the authenticated user. Safeguard event listeners use SignalR to make
+    /// long-lived connections to Safeguard.
     /// </summary>
     public interface ISafeguardEventListener : IDisposable
     {

--- a/SafeguardDotNet/Event/ISafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/ISafeguardEventListener.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace OneIdentity.SafeguardDotNet
+namespace OneIdentity.SafeguardDotNet.Event
 {
     public delegate void SafeguardEventHandler(string eventName, string eventBody);
 

--- a/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Security;
 using OneIdentity.SafeguardDotNet.A2A;
+using Serilog;
 
 namespace OneIdentity.SafeguardDotNet.Event
 {
@@ -16,15 +17,16 @@ namespace OneIdentity.SafeguardDotNet.Event
             _a2AContext = a2AContext;
             _apiKey = apiKey.Copy();
             RegisterEventHandler("AssetAccountPasswordUpdated", handler);
+            Log.Information("Persistent A2A event listener successfully created.");
         }
 
         protected override SafeguardEventListener ReconnectEventListener()
         {
-            // passing null for handler because it will be overridden in PersistentSafeguardEventListenerBase
-            return (SafeguardEventListener) _a2AContext.GetEventListener(_apiKey, null);
+            // passing in a bogus handler because it will be overridden in PersistentSafeguardEventListenerBase
+            return (SafeguardEventListener) _a2AContext.GetEventListener(_apiKey, (name, body) => { });
         }
 
-        protected virtual void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (_disposed || !disposing)
                 return;

--- a/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Security;
+﻿using System.Security;
 using OneIdentity.SafeguardDotNet.A2A;
 using Serilog;
 

--- a/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Security;
+using OneIdentity.SafeguardDotNet.A2A;
+
+namespace OneIdentity.SafeguardDotNet.Event
+{
+    internal class PersistentSafeguardA2AEventListener : PersistentSafeguardEventListenerBase
+    {
+        private bool _disposed;
+
+        private readonly ISafeguardA2AContext _a2AContext;
+        private readonly SecureString _apiKey;
+
+        public PersistentSafeguardA2AEventListener(ISafeguardA2AContext a2AContext, SecureString apiKey, SafeguardEventHandler handler)
+        {
+            _a2AContext = a2AContext;
+            _apiKey = apiKey.Copy();
+            RegisterEventHandler("AssetAccountPasswordUpdated", handler);
+        }
+
+        protected override SafeguardEventListener ReconnectEventListener()
+        {
+            // passing null for handler because it will be overridden in PersistentSafeguardEventListenerBase
+            return (SafeguardEventListener) _a2AContext.GetEventListener(_apiKey, null);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed || !disposing)
+                return;
+            try
+            {
+                base.Dispose(true);
+                _apiKey.Dispose();
+                _a2AContext?.Dispose();
+            }
+            finally
+            {
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/SafeguardDotNet/Event/PersistentSafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardEventListener.cs
@@ -1,4 +1,6 @@
-﻿namespace OneIdentity.SafeguardDotNet.Event
+﻿using Serilog;
+
+namespace OneIdentity.SafeguardDotNet.Event
 {
     internal class PersistentSafeguardEventListener : PersistentSafeguardEventListenerBase
     {
@@ -9,6 +11,7 @@
         public PersistentSafeguardEventListener(ISafeguardConnection connection)
         {
             _connection = connection;
+            Log.Information("Persistent event listener successfully created.");
         }
 
         protected override SafeguardEventListener ReconnectEventListener()

--- a/SafeguardDotNet/Event/PersistentSafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardEventListener.cs
@@ -1,0 +1,36 @@
+﻿namespace OneIdentity.SafeguardDotNet.Event
+{
+    internal class PersistentSafeguardEventListener : PersistentSafeguardEventListenerBase
+    {
+        private bool _disposed;
+
+        private readonly ISafeguardConnection _connection;
+
+        public PersistentSafeguardEventListener(ISafeguardConnection connection)
+        {
+            _connection = connection;
+        }
+
+        protected override SafeguardEventListener ReconnectEventListener()
+        {
+            if (_connection.GetAccessTokenLifetimeRemaining() == 0)
+                _connection.RefreshAccessToken();
+            return (SafeguardEventListener)_connection.GetEventListener();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_disposed || !disposing)
+                return;
+            try
+            {
+                base.Dispose(true);
+                _connection?.Dispose();
+            }
+            finally
+            {
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
@@ -40,6 +40,8 @@ namespace OneIdentity.SafeguardDotNet.Event
                 {
                     try
                     {
+                        _eventListener?.Dispose();
+                        Log.Information("Attempting to connect and start internal event listener.");
                         _eventListener = ReconnectEventListener();
                         _eventListener.SetEventHandlerRegistry(_eventHandlerRegistry);
                         _eventListener.Start();
@@ -48,7 +50,8 @@ namespace OneIdentity.SafeguardDotNet.Event
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "Persistent event listener connect error, sleeping for 5 seconds...");
+                        Log.Warning("Internal event listener connection error (see debug for more information), sleeping for 5 seconds...");
+                        Log.Debug(ex, "Internal event listener connection error.");
                         Thread.Sleep(5000);
                     }
                 }

--- a/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace OneIdentity.SafeguardDotNet.Event
+{
+    internal abstract class PersistentSafeguardEventListenerBase : ISafeguardEventListener
+    {
+        private bool _disposed;
+
+        private SafeguardEventListener _eventListener;
+        private readonly EventHandlerRegistry _eventHandlerRegistry;
+
+        private Task _reconnectTask;
+        private CancellationTokenSource _reconnectCancel;
+
+        protected PersistentSafeguardEventListenerBase()
+        {
+            _eventHandlerRegistry = new EventHandlerRegistry();
+        }
+
+        public void RegisterEventHandler(string eventName, SafeguardEventHandler handler)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("PersistentSafeguardEventListener");
+            _eventHandlerRegistry.RegisterEventHandler(eventName, handler);
+        }
+
+        protected abstract SafeguardEventListener ReconnectEventListener();
+
+        private void PersistentReconnectAndStart()
+        {
+            if (_reconnectTask != null)
+                return;
+            _reconnectCancel = new CancellationTokenSource();
+            _reconnectTask = Task.Run(() =>
+            {
+                while (!_reconnectCancel.IsCancellationRequested)
+                {
+                    try
+                    {
+                        _eventListener = ReconnectEventListener();
+                        _eventListener.SetEventHandlerRegistry(_eventHandlerRegistry);
+                        _eventListener.Start();
+                        _eventListener.SetDisconnectHandler(PersistentReconnectAndStart);
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Persistent event listener reconnect error, sleeping for 5 seconds...");
+                        Thread.Sleep(5000);
+                    }
+                }
+            }, _reconnectCancel.Token);
+            _reconnectTask.ContinueWith((task) =>
+            {
+                _reconnectCancel.Dispose();
+                _reconnectCancel = null;
+                _reconnectTask = null;
+            });
+        }
+
+        public void Start()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("PersistentSafeguardEventListener");
+            PersistentReconnectAndStart();
+        }
+
+        public void Stop()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("PersistentSafeguardEventListener");
+            _reconnectCancel?.Cancel();
+            _eventListener?.Stop();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed || !disposing)
+                return;
+            try
+            {
+                _eventListener?.Dispose();
+            }
+            finally
+            {
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
@@ -48,7 +48,7 @@ namespace OneIdentity.SafeguardDotNet.Event
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "Persistent event listener reconnect error, sleeping for 5 seconds...");
+                        Log.Error(ex, "Persistent event listener connect error, sleeping for 5 seconds...");
                         Thread.Sleep(5000);
                     }
                 }
@@ -58,6 +58,8 @@ namespace OneIdentity.SafeguardDotNet.Event
                 _reconnectCancel.Dispose();
                 _reconnectCancel = null;
                 _reconnectTask = null;
+                if (!task.IsFaulted)
+                    Log.Information("Internal event listener successfully connected and started.");
             });
         }
 
@@ -65,6 +67,7 @@ namespace OneIdentity.SafeguardDotNet.Event
         {
             if (_disposed)
                 throw new ObjectDisposedException("PersistentSafeguardEventListener");
+            Log.Information("Internal event listener requested to start.");
             PersistentReconnectAndStart();
         }
 
@@ -72,6 +75,7 @@ namespace OneIdentity.SafeguardDotNet.Event
         {
             if (_disposed)
                 throw new ObjectDisposedException("PersistentSafeguardEventListener");
+            Log.Information("Internal event listener requested to stop.");
             _reconnectCancel?.Cancel();
             _eventListener?.Stop();
         }

--- a/SafeguardDotNet/Event/SafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/SafeguardEventListener.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNet.SignalR.Client.Http;
 using Newtonsoft.Json.Linq;
 using Serilog;
 
-namespace OneIdentity.SafeguardDotNet
+namespace OneIdentity.SafeguardDotNet.Event
 {
     using DelegateRegistry = Dictionary<string, List<SafeguardEventHandler>>;
 

--- a/SafeguardDotNet/Event/SafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/SafeguardEventListener.cs
@@ -65,11 +65,10 @@ namespace OneIdentity.SafeguardDotNet.Event
 
         private void HandleDisconnect()
         {
-            if (_isStarted)
-            {
-                Log.Information("SignalR disconnect detected, calling handler...");
-                _disconnectHandler();
-            }
+            if (!_isStarted)
+                return;
+            Log.Warning("SignalR disconnect detected, calling handler...");
+            _disconnectHandler();
         }
 
         private void CleanupConnection()

--- a/SafeguardDotNet/Event/SafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/SafeguardEventListener.cs
@@ -3,6 +3,7 @@ using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNet.SignalR.Client;
 using Microsoft.AspNet.SignalR.Client.Http;
+using Serilog;
 
 namespace OneIdentity.SafeguardDotNet.Event
 {
@@ -65,7 +66,10 @@ namespace OneIdentity.SafeguardDotNet.Event
         private void HandleDisconnect()
         {
             if (_isStarted)
+            {
+                Log.Information("SignalR disconnect detected, calling handler...");
                 _disconnectHandler();
+            }
         }
 
         private void CleanupConnection()

--- a/SafeguardDotNet/Event/SafeguardEventListenerDisconnectedException.cs
+++ b/SafeguardDotNet/Event/SafeguardEventListenerDisconnectedException.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.Serialization;
+
+namespace OneIdentity.SafeguardDotNet.Event
+{
+    public class SafeguardEventListenerDisconnectedException : SafeguardDotNetException
+    {
+        public SafeguardEventListenerDisconnectedException() 
+            : base("SafeguardEventListener has permanently disconnected SignalR connection")
+        {
+        }
+
+        protected SafeguardEventListenerDisconnectedException
+            (SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/SafeguardDotNet/ISafeguardConnection.cs
+++ b/SafeguardDotNet/ISafeguardConnection.cs
@@ -56,7 +56,10 @@ namespace OneIdentity.SafeguardDotNet
         /// <summary>
         /// Gets a Safeguard event listener. You will need to call the RegisterEventHandler()
         /// method to establish callbacks. Then, you just have to call Start().  Call Stop()
-        /// when you are finished.
+        /// when you are finished. The event listener returned by this method will not
+        /// automatically recover from a SignalR timeout which occurs when there is a 30+
+        /// second outage. To get an event listener that supports recovering from longer term
+        /// outages, please use Safeguard.Event to request a persistent event listener.
         /// </summary>
         /// <returns>The event listener.</returns>
         ISafeguardEventListener GetEventListener();

--- a/SafeguardDotNet/ISafeguardConnection.cs
+++ b/SafeguardDotNet/ISafeguardConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using OneIdentity.SafeguardDotNet.Event;
 
 namespace OneIdentity.SafeguardDotNet
 {

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security;
+using OneIdentity.SafeguardDotNet.A2A;
 using OneIdentity.SafeguardDotNet.Authentication;
 
 namespace OneIdentity.SafeguardDotNet

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -195,6 +195,7 @@ namespace OneIdentity.SafeguardDotNet
             /// event listeners can handle longer term service outages to reconnect SignalR even after it times out. It is
             /// recommended to use these interfaces when listening for Safeguard events from a long-running service.
             /// </summary>
+            // ReSharper disable once MemberHidesStaticFromOuterClass
             public static class Event
             {
                 /// <summary>

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -98,6 +98,64 @@ namespace OneIdentity.SafeguardDotNet
         }
 
         /// <summary>
+        /// This static class provides access to Safeguard Event functionality with persistent event listeners. Persistent
+        /// event listeners can handle longer term service outages to reconnect SignalR even after it times out. It is
+        /// recommended to use these interfaces when listening for Safeguard events from a long-running service.
+        /// </summary>
+        public static class Event
+        {
+            /// <summary>
+            /// Get a persistent event listener using a username and password credentia for authentication.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="provider">Safeguard authentication provider name (e.g. local).</param>
+            /// <param name="username">User name to use for authentication.</param>
+            /// <param name="password">User password to use for authentication.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
+            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress, string provider,
+                string username, SecureString password, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
+            {
+                return new PersistentSafeguardEventListener(GetConnection(
+                    new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion, ignoreSsl)));
+            }
+
+            /// <summary>
+            /// Get a persistent event listener using a client certificate from the certificate store for authentication.
+            /// Use PowerShell to list certificates with SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
+            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
+                string certificateThumbprint, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
+            {
+                return new PersistentSafeguardEventListener(GetConnection(
+                    new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion, ignoreSsl)));
+            }
+
+            /// <summary>
+            /// Get a persistent event listener using a client certificate stored in a file.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
+            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
+                string certificatePath, SecureString certificatePassword, int apiVersion = DefaultApiVersion,
+                bool ignoreSsl = false)
+            {
+                return new PersistentSafeguardEventListener(GetConnection(new CertificateAuthenticator(networkAddress,
+                    certificatePath, certificatePassword, apiVersion, ignoreSsl)));
+            }
+        }
+
+        /// <summary>
         /// This static class provides access to Safeguard A2A functionality.
         /// </summary>
         public static class A2A
@@ -179,64 +237,6 @@ namespace OneIdentity.SafeguardDotNet
                         new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion,
                             ignoreSsl), apiKey, handler);
                 }
-            }
-        }
-
-        /// <summary>
-        /// This static class provides access to Safeguard Event functionality with persistent event listeners. Persistent
-        /// event listeners can handle longer term service outages to reconnect SignalR even after it times out. It is
-        /// recommended to use these interfaces when listening for Safeguard events from a long-running service.
-        /// </summary>
-        public static class Event
-        {
-            /// <summary>
-            /// Get a persistent event listener using a username and password credentia for authentication.
-            /// </summary>
-            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
-            /// <param name="provider">Safeguard authentication provider name (e.g. local).</param>
-            /// <param name="username">User name to use for authentication.</param>
-            /// <param name="password">User password to use for authentication.</param>
-            /// <param name="apiVersion">Target API version to use.</param>
-            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
-            /// <returns>New persistent Safeguard event listener.</returns>
-            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress, string provider,
-                string username, SecureString password, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
-            {
-                return new PersistentSafeguardEventListener(GetConnection(
-                    new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion, ignoreSsl)));
-            }
-
-            /// <summary>
-            /// Get a persistent event listener using a client certificate from the certificate store for authentication.
-            /// Use PowerShell to list certificates with SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
-            /// </summary>
-            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
-            /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
-            /// <param name="apiVersion">Target API version to use.</param>
-            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
-            /// <returns>New persistent Safeguard event listener.</returns>
-            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
-                string certificateThumbprint, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
-            {
-                return new PersistentSafeguardEventListener(GetConnection(
-                    new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion, ignoreSsl)));
-            }
-
-            /// <summary>
-            /// Get a persistent event listener using a client certificate stored in a file.
-            /// </summary>
-            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
-            /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
-            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
-            /// <param name="apiVersion">Target API version to use.</param>
-            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
-            /// <returns>New persistent Safeguard event listener.</returns>
-            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
-                string certificatePath, SecureString certificatePassword, int apiVersion = DefaultApiVersion,
-                bool ignoreSsl = false)
-            {
-                return new PersistentSafeguardEventListener(GetConnection(new CertificateAuthenticator(networkAddress,
-                    certificatePath, certificatePassword, apiVersion, ignoreSsl)));
             }
         }
     }

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -66,8 +66,8 @@ namespace OneIdentity.SafeguardDotNet
         }
 
         /// <summary>
-        /// Connect to Safeguard API using a certificate from the certificate store.  Use PowerShell to list certificates with
-        /// SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
+        /// Connect to Safeguard API using a client certificate from the certificate store.  Use PowerShell to list
+        /// certificates with SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
         /// </summary>
         /// <param name="networkAddress">Network address of Safeguard appliance.</param>
         /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
@@ -82,7 +82,7 @@ namespace OneIdentity.SafeguardDotNet
         }
 
         /// <summary>
-        /// Connect to Safeguard API using a certificate stored in a file.
+        /// Connect to Safeguard API using a client certificate stored in a file.
         /// </summary>
         /// <param name="networkAddress">Network address of Safeguard appliance.</param>
         /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
@@ -133,8 +133,23 @@ namespace OneIdentity.SafeguardDotNet
             }
         }
 
+        /// <summary>
+        /// This static class provides access to Safeguard Event functionality with persistent event listeners. Persistent
+        /// event listeners can handle longer term service outages to reconnect SignalR even after it times out. It is
+        /// recommended to use these interfaces when listening for Safeguard events from a long-running service.
+        /// </summary>
         public static class Event
         {
+            /// <summary>
+            /// Get a persistent event listener using a username and password credentia for authentication.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="provider">Safeguard authentication provider name (e.g. local).</param>
+            /// <param name="username">User name to use for authentication.</param>
+            /// <param name="password">User password to use for authentication.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
             public static ISafeguardEventListener GetPersistentEventListener(string networkAddress, string provider,
                 string username, SecureString password, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
             {
@@ -142,6 +157,15 @@ namespace OneIdentity.SafeguardDotNet
                     new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion, ignoreSsl)));
             }
 
+            /// <summary>
+            /// Get a persistent event listener using a client certificate from the certificate store for authentication.
+            /// Use PowerShell to list certificates with SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
             public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
                 string certificateThumbprint, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
             {
@@ -149,6 +173,15 @@ namespace OneIdentity.SafeguardDotNet
                     new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion, ignoreSsl)));
             }
 
+            /// <summary>
+            /// Get a persistent event listener using a client certificate stored in a file.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
             public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
                 string certificatePath, SecureString certificatePassword, int apiVersion = DefaultApiVersion,
                 bool ignoreSsl = false)
@@ -157,6 +190,17 @@ namespace OneIdentity.SafeguardDotNet
                     certificatePath, certificatePassword, apiVersion, ignoreSsl)));
             }
 
+            /// <summary>
+            /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+            /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A.
+            /// </summary>
+            /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+            /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent A2A event listener.</returns>
             public static ISafeguardEventListener GetPersistentA2AEventListener(SafeguardEventHandler handler,
                 SecureString apiKey, string networkAddress, string certificateThumbprint,
                 int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
@@ -166,6 +210,18 @@ namespace OneIdentity.SafeguardDotNet
                         handler);
             }
 
+            /// <summary>
+            /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+            /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A.
+            /// </summary>
+            /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+            /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+            /// <returns>New persistent A2A event listener.</returns>
             public static ISafeguardEventListener GetPersistentA2AEventListener(SafeguardEventHandler handler,
                 SecureString apiKey, string networkAddress, string certificatePath, SecureString certificatePassword,
                 int apiVersion = DefaultApiVersion, bool ignoreSsl = false)

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -131,6 +131,55 @@ namespace OneIdentity.SafeguardDotNet
             {
                 return new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion, ignoreSsl);
             }
+
+            /// <summary>
+            /// This static class provides access to Safeguard A2A Event functionality with persistent event listeners. Persistent
+            /// event listeners can handle longer term service outages to reconnect SignalR even after it times out. It is
+            /// recommended to use these interfaces when listening for Safeguard events from a long-running service.
+            /// </summary>
+            public static class Event
+            {
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A.
+                /// </summary>
+                /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(SecureString apiKey,
+                    SafeguardEventHandler handler, string networkAddress, string certificateThumbprint,
+                    int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl), apiKey,
+                            handler);
+                }
+
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A.
+                /// </summary>
+                /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+                /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <param name="ignoreSsl">Ignore server certificate validation.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(SecureString apiKey,
+                    SafeguardEventHandler handler, string networkAddress, string certificatePath,
+                    SecureString certificatePassword, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion,
+                            ignoreSsl), apiKey, handler);
+                }
+            }
         }
 
         /// <summary>
@@ -188,47 +237,6 @@ namespace OneIdentity.SafeguardDotNet
             {
                 return new PersistentSafeguardEventListener(GetConnection(new CertificateAuthenticator(networkAddress,
                     certificatePath, certificatePassword, apiVersion, ignoreSsl)));
-            }
-
-            /// <summary>
-            /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
-            /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A.
-            /// </summary>
-            /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
-            /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
-            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
-            /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
-            /// <param name="apiVersion">Target API version to use.</param>
-            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
-            /// <returns>New persistent A2A event listener.</returns>
-            public static ISafeguardEventListener GetPersistentA2AEventListener(SafeguardEventHandler handler,
-                SecureString apiKey, string networkAddress, string certificateThumbprint,
-                int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
-            {
-                return new PersistentSafeguardA2AEventListener(
-                    new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl), apiKey,
-                        handler);
-            }
-
-            /// <summary>
-            /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
-            /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A.
-            /// </summary>
-            /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
-            /// <param name="apiKey">API key correspondingto the configured account to listen for.</param>
-            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
-            /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
-            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
-            /// <param name="apiVersion">Target API version to use.</param>
-            /// <param name="ignoreSsl">Ignore server certificate validation.</param>
-            /// <returns>New persistent A2A event listener.</returns>
-            public static ISafeguardEventListener GetPersistentA2AEventListener(SafeguardEventHandler handler,
-                SecureString apiKey, string networkAddress, string certificatePath, SecureString certificatePassword,
-                int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
-            {
-                return new PersistentSafeguardA2AEventListener(
-                    new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion,
-                        ignoreSsl), apiKey, handler);
             }
         }
     }

--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -47,7 +47,7 @@ namespace OneIdentity.SafeguardDotNet
             if (lifetime > 0)
                 Log.Information("Access token lifetime remaining (in minutes): {AccessTokenLifetime}", lifetime);
             else
-                Log.Information("Unable to get valid access token");
+                Log.Information("Access token invalid or server unavailable");
             return lifetime;
         }
 

--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OneIdentity.SafeguardDotNet.Authentication;
+using OneIdentity.SafeguardDotNet.Event;
 using RestSharp;
 using Serilog;
 

--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -44,7 +44,10 @@ namespace OneIdentity.SafeguardDotNet
             if (_disposed)
                 throw new ObjectDisposedException("SafeguardConnection");
             var lifetime = _authenticationMechanism.GetAccessTokenLifetimeRemaining();
-            Log.Information("Access token lifetime remaining (in minutes): {AccessTokenLifetime}", lifetime);
+            if (lifetime > 0)
+                Log.Information("Access token lifetime remaining (in minutes): {AccessTokenLifetime}", lifetime);
+            else
+                Log.Information("Unable to get valid access token");
             return lifetime;
         }
 

--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -129,6 +129,8 @@ namespace OneIdentity.SafeguardDotNet
 
         public ISafeguardEventListener GetEventListener()
         {
+            if (_disposed)
+                throw new ObjectDisposedException("SafeguardConnection");
             var eventListener = new SafeguardEventListener(
                 $"https://{_authenticationMechanism.NetworkAddress}/service/event",
                 _authenticationMechanism.GetAccessToken(), _authenticationMechanism.IgnoreSsl);

--- a/SafeguardDotNet/SafeguardDotNet.csproj
+++ b/SafeguardDotNet/SafeguardDotNet.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="RestSharp" Version="106.4.0" />
+    <PackageReference Include="RestSharp" Version="106.4.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/SafeguardDotNet/SafeguardDotNet.csproj
+++ b/SafeguardDotNet/SafeguardDotNet.csproj
@@ -24,8 +24,4 @@
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Event\" />
-  </ItemGroup>
-
 </Project>

--- a/SafeguardDotNet/SafeguardDotNet.csproj
+++ b/SafeguardDotNet/SafeguardDotNet.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Event\" />
+  </ItemGroup>
+
 </Project>

--- a/Test/SafeguardDotNetA2aTool/Program.cs
+++ b/Test/SafeguardDotNetA2aTool/Program.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Security;
 using CommandLine;
 using OneIdentity.SafeguardDotNet;
+using OneIdentity.SafeguardDotNet.A2A;
 using Serilog;
 
 namespace SafeguardDotNetA2aTool
 {
-    class Program
+    internal class Program
     {
         private static SecureString PromptForSecret(string name)
         {

--- a/Test/SafeguardDotNetEventTool/Program.cs
+++ b/Test/SafeguardDotNetEventTool/Program.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Security;
 using CommandLine;
 using OneIdentity.SafeguardDotNet;
+using OneIdentity.SafeguardDotNet.A2A;
 using Serilog;
 
 namespace SafeguardDotNetEventTool
 {
-    class Program
+    internal class Program
     {
         private static SecureString PromptForSecret(string name)
         {

--- a/Test/SafeguardDotNetEventTool/Program.cs
+++ b/Test/SafeguardDotNetEventTool/Program.cs
@@ -4,6 +4,7 @@ using System.Security;
 using CommandLine;
 using OneIdentity.SafeguardDotNet;
 using OneIdentity.SafeguardDotNet.A2A;
+using OneIdentity.SafeguardDotNet.Event;
 using Serilog;
 
 namespace SafeguardDotNetEventTool
@@ -88,6 +89,57 @@ namespace SafeguardDotNetEventTool
         }
 
 
+        private static ISafeguardEventListener CreatePersistentListener(ToolOptions opts)
+        {
+            if (!string.IsNullOrEmpty(opts.ApiKey))
+            {
+                void A2AHandler(string name, string body)
+                {
+                    Log.Information("Received A2AHandler Event: {EventBody}", body);
+                }
+                if (!string.IsNullOrEmpty(opts.CertificateFile))
+                {
+                    var password = HandlePassword(opts.ReadPassword);
+                    return Safeguard.Event.GetPersistentA2AEventListener(A2AHandler, opts.ApiKey.ToSecureString(),
+                        opts.Appliance, opts.CertificateFile, password, opts.ApiVersion, opts.Insecure);
+
+                }
+                if (!string.IsNullOrEmpty(opts.Thumbprint))
+                    return Safeguard.Event.GetPersistentA2AEventListener(A2AHandler, opts.ApiKey.ToSecureString(),
+                        opts.Appliance, opts.Thumbprint, opts.ApiVersion, opts.Insecure);
+                throw new Exception("Must specify CertificateFile or Thumbprint");
+            }
+            void Handler(string name, string body)
+            {
+                Log.Information("Received A2A Event: {EventBody}", body);
+            }
+            ISafeguardEventListener listener;
+            if (!string.IsNullOrEmpty(opts.Username))
+            {
+                var password = HandlePassword(opts.ReadPassword);
+                listener = Safeguard.Event.GetPersistentEventListener(opts.Appliance, opts.IdentityProvider, opts.Username,
+                    password, opts.ApiVersion, opts.Insecure);
+            }
+            else if (!string.IsNullOrEmpty(opts.CertificateFile))
+            {
+                var password = HandlePassword(opts.ReadPassword);
+                listener = Safeguard.Event.GetPersistentEventListener(opts.Appliance, opts.CertificateFile, password,
+                    opts.ApiVersion, opts.Insecure);
+            }
+            else if (!string.IsNullOrEmpty(opts.Thumbprint))
+            {
+                listener = Safeguard.Event.GetPersistentEventListener(opts.Appliance, opts.Thumbprint, opts.ApiVersion,
+                    opts.Insecure);
+            }
+            else
+            {
+                throw new Exception("Must specify Username, CertificateFile, or Thumbprint");
+            }
+            listener.RegisterEventHandler(opts.Event, Handler);
+            return listener;
+        }
+
+
         private static void Execute(ToolOptions opts)
         {
             try
@@ -124,17 +176,30 @@ namespace SafeguardDotNetEventTool
                 }
                 else
                 {
-                    using (var context = CreateA2AContext(opts))
+                    if (opts.Persistent)
                     {
-                        using (var listener = context.GetEventListener(opts.ApiKey.ToSecureString(), ((name, body) =>
-                        {
-                            Log.Information("Received A2A Event: {EventBody}", body);
-                        })))
+                        using (var listener = CreatePersistentListener(opts))
                         {
                             listener.Start();
                             Log.Information("Press any key to shut down the event listener...");
                             Console.ReadKey();
                             listener.Stop();
+                        }
+                    }
+                    else
+                    {
+                        using (var context = CreateA2AContext(opts))
+                        {
+                            using (var listener = context.GetEventListener(opts.ApiKey.ToSecureString(), ((name, body) =>
+                            {
+                                Log.Information("Received A2A Event: {EventBody}", body);
+                            })))
+                            {
+                                listener.Start();
+                                Log.Information("Press any key to shut down the event listener...");
+                                Console.ReadKey();
+                                listener.Stop();
+                            }
                         }
                     }
                 }

--- a/Test/SafeguardDotNetEventTool/Program.cs
+++ b/Test/SafeguardDotNetEventTool/Program.cs
@@ -100,12 +100,12 @@ namespace SafeguardDotNetEventTool
                 if (!string.IsNullOrEmpty(opts.CertificateFile))
                 {
                     var password = HandlePassword(opts.ReadPassword);
-                    return Safeguard.Event.GetPersistentA2AEventListener(A2AHandler, opts.ApiKey.ToSecureString(),
+                    return Safeguard.A2A.Event.GetPersistentA2AEventListener(opts.ApiKey.ToSecureString(), A2AHandler,
                         opts.Appliance, opts.CertificateFile, password, opts.ApiVersion, opts.Insecure);
 
                 }
                 if (!string.IsNullOrEmpty(opts.Thumbprint))
-                    return Safeguard.Event.GetPersistentA2AEventListener(A2AHandler, opts.ApiKey.ToSecureString(),
+                    return Safeguard.A2A.Event.GetPersistentA2AEventListener(opts.ApiKey.ToSecureString(), A2AHandler,
                         opts.Appliance, opts.Thumbprint, opts.ApiVersion, opts.Insecure);
                 throw new Exception("Must specify CertificateFile or Thumbprint");
             }

--- a/Test/SafeguardDotNetEventTool/ToolOptions.cs
+++ b/Test/SafeguardDotNetEventTool/ToolOptions.cs
@@ -40,11 +40,11 @@ namespace SafeguardDotNetEventTool
             HelpText = "File path for client certificate")]
         public string CertificateFile { get; set; }
 
-        [Option('A', "ApiKey", Required = true, Default = null,
+        [Option('A', "ApiKey", Required = false, Default = null,
             HelpText = "ApiKey for listening to Safeguard A2A")]
         public string ApiKey { get; set; }
 
-        [Option('E', "Event", Required = true, SetName = "PasswordSet",
+        [Option('E', "Event", Required = false,
             HelpText = "Safeguard event to listen for")]
         public string Event { get; set; }
 

--- a/Test/SafeguardDotNetEventTool/ToolOptions.cs
+++ b/Test/SafeguardDotNetEventTool/ToolOptions.cs
@@ -47,5 +47,8 @@ namespace SafeguardDotNetEventTool
         [Option('E', "Event", Required = true, SetName = "PasswordSet",
             HelpText = "Safeguard event to listen for")]
         public string Event { get; set; }
+
+        [Option('P', "Persistent", HelpText = "Use persistent listeners")]
+        public bool Persistent { get; set; }
     }
 }


### PR DESCRIPTION
Added the Safeguard.Event and Safeguard.A2A.Event resources for creating persistent event listeners.
These are robust SignalR event listeners that will reconnect even after a SignalR timeout.
They are a great building block for integration components.