### PR TITLE
ServiceNow ticket system access request approver sample

### DIFF
--- a/SafeguardDotNet/CertificateUtilities.cs
+++ b/SafeguardDotNet/CertificateUtilities.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Security;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
 namespace OneIdentity.SafeguardDotNet
@@ -48,6 +49,44 @@ namespace OneIdentity.SafeguardDotNet
             catch (Exception ex)
             {
                 throw new SafeguardDotNetException($"Failure to get certificate from file={filepath}", ex);
+            }
+        }
+
+        private static SecureString GenerateRandomSecureString(int size)
+        {
+            var secureString = new SecureString();
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                var idx = 0;
+                var data = new byte[size * 8];
+                rng.GetBytes(data);
+                for (var i = 0; i < size; i++)
+                {
+                    for (; idx < data.Length; idx++)
+                    {
+                        if (data[idx] > 0x20 && data[idx] < 127)
+                        {
+                            secureString.AppendChar((char)data[idx]);
+                            data[idx] = 0x00;
+                            break;
+                        }
+                        data[idx] = 0x00;
+                    }
+                    if (idx == data.Length)
+                        throw new Exception("Failed to generate secure string with 8x key material");
+                }
+                Array.Clear(data, 0, data.Length);
+            }
+            return secureString;
+        }
+
+        public static X509Certificate2 Copy(X509Certificate2 certificate)
+        {
+            using (var password = GenerateRandomSecureString(24))
+            {
+                var export = certificate.Export(X509ContentType.Pkcs12, password);
+                return new X509Certificate2(export, password,
+                    X509KeyStorageFlags.DefaultKeySet | X509KeyStorageFlags.PersistKeySet);
             }
         }
     }

--- a/SafeguardDotNet/Event/SafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/SafeguardEventListener.cs
@@ -44,7 +44,7 @@ namespace OneIdentity.SafeguardDotNet.Event
         public SafeguardEventListener(string eventUrl, X509Certificate2 clientCertificate, SecureString apiKey,
             bool ignoreSsl) : this(eventUrl, ignoreSsl)
         {
-            _clientCertificate = clientCertificate;
+            _clientCertificate = CertificateUtilities.Copy(clientCertificate);
             _apiKey = apiKey.Copy();
         }
 

--- a/Samples/ServiceNowTicketValidator/ConfigUtils.cs
+++ b/Samples/ServiceNowTicketValidator/ConfigUtils.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Configuration;
+using Serilog;
+
+namespace ServiceNowTicketValidator
+{
+    static class ConfigUtils
+    {
+        public static string ReadRequiredSettingFromAppConfig(string key, string description)
+        {
+            try
+            {
+                var value = ConfigurationManager.AppSettings[key];
+                if (!string.IsNullOrEmpty(value))
+                    return value;
+                Log.Error($"{key} is required in App.Config");
+                throw new Exception($"Unable to start SlackBotService with empty {description}.");
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                Log.Error(ex, $"{key} is required in App.Config");
+                throw new Exception($"Unable to start SlackBotService without {description}.", ex);
+            }
+        }
+
+        public static string ReadSettingFromAppConfigIfPresent(string key)
+        {
+            try
+            {
+                var value = ConfigurationManager.AppSettings[key];
+                return !string.IsNullOrEmpty(value) ? value : null;
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/ConfigUtils.cs
+++ b/Samples/ServiceNowTicketValidator/ConfigUtils.cs
@@ -14,12 +14,12 @@ namespace ServiceNowTicketValidator
                 if (!string.IsNullOrEmpty(value))
                     return value;
                 Log.Error($"{key} is required in App.Config");
-                throw new Exception($"Unable to start SlackBotService with empty {description}.");
+                throw new Exception($"Unable to start ServiceNowTicketValidator with empty {description}.");
             }
             catch (ConfigurationErrorsException ex)
             {
                 Log.Error(ex, $"{key} is required in App.Config");
-                throw new Exception($"Unable to start SlackBotService without {description}.", ex);
+                throw new Exception($"Unable to start ServiceNowTicketValidator without {description}.", ex);
             }
         }
 
@@ -30,7 +30,7 @@ namespace ServiceNowTicketValidator
                 var value = ConfigurationManager.AppSettings[key];
                 return !string.IsNullOrEmpty(value) ? value : null;
             }
-            catch (ConfigurationErrorsException ex)
+            catch (ConfigurationErrorsException)
             {
                 return null;
             }

--- a/Samples/ServiceNowTicketValidator/DTOs/AccessRequest.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/AccessRequest.cs
@@ -1,0 +1,38 @@
+﻿namespace ServiceNowTicketValidator.DTOs
+{
+    // There are more fields available. I trimmed out what I thought was most useful.
+    // I decided to remove all time-based data, but it could be added back.
+    internal class AccessRequest
+    {
+        public string Id { get; set; }
+        public bool IsEmergency { get; set; }
+        public string State { get; set; }
+        public string TicketNumber { get; set; }
+
+        public string AccessRequestType { get; set; }
+        public string AccountRequestType { get; set; }
+        public int AssetId { get; set; }
+        public string AssetName { get; set; }
+        public string AssetNetworkAddress { get; set; }
+
+        public int AccountId { get; set; }
+        public string AccountName { get; set; }
+        public string AccountDomainName { get; set; }
+        public int AccountSystemId { get; set; }
+        public string AccountSystemName { get; set; }
+
+        public string ReasonCode { get; set; }
+        public string ReasonComment { get; set; }
+        public int RequestedDurationDays { get; set; }
+        public int RequestedDurationHours { get; set; }
+        public int RequestedDurationMinutes { get; set; }
+        public int DurationInMinutes { get; set; }
+
+        public string RequesterId { get; set; }
+        public string RequesterDisplayName { get; set; }
+        public string RequesterEmailAddress { get; set; }
+
+        public int CurrentApprovalCount { get; set; }
+        public int RequiredApprovalCount { get; set; }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/DTOs/AccessRequestApprovalPendingEvent.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/AccessRequestApprovalPendingEvent.cs
@@ -1,0 +1,18 @@
+﻿namespace ServiceNowTicketValidator.DTOs
+{
+    internal class AccessRequestApprovalPendingEvent
+    {
+        public string ApplianceId { get; set; }
+        public string RequestId { get; set; }
+
+        public int AssetId { get; set; }
+        public string AssetName { get; set; }
+        public int AccountId { get; set; }
+        public string AccountName { get; set; }
+
+        public string Requester { get; set; }
+        public int RequesterId { get; set; }
+        public string Comment { get; set; }
+        public int DurationInMinutes { get; set; }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/DTOs/Incident.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/Incident.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace ServiceNowTicketValidator.DTOs
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class Incident
+    {
+        public string number { get; set; }
+        public string state { get; set; }
+        public bool Active => active != "false";
+        public string active { get; set; }
+        public string opened_at { get; set; }
+        public string resolved_at { get; set; }
+        public string closed_at { get; set; }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/DTOs/ServiceNowCmdbCi.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/ServiceNowCmdbCi.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace ServiceNowTicketValidator.DTOs
+{
+    // There are more fields available. I trimmed out what I thought was most useful.
+    // Anything could be added back of course.
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class ServiceNowCmdbCi
+    {
+        public string sys_id { get; set; }
+        public string asset { get; set; }
+        public string asset_tag { get; set; }
+        public string model_number { get; set; }
+        public string model_id { get; set; }
+        public string serial_number { get; set; }
+        public string sys_tags { get; set; }
+
+        public string name { get; set; }
+        public string fqdn { get; set; }
+        public string dns_domain { get; set; }
+        public string ip_address { get; set; }
+        public string short_description { get; set; }
+        public string operational_status { get; set; }
+
+        public string owned_by { get; set; }
+        public string managed_by { get; set; }
+        public string checked_out { get; set; }
+        public string department { get; set; }
+        public ServiceNowLink assigned_to { get; set; }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/DTOs/ServiceNowCmdbCi.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/ServiceNowCmdbCi.cs
@@ -26,6 +26,6 @@ namespace ServiceNowTicketValidator.DTOs
         public string managed_by { get; set; }
         public string checked_out { get; set; }
         public string department { get; set; }
-        public ServiceNowLink assigned_to { get; set; }
+        public string assigned_to { get; set; }
     }
 }

--- a/Samples/ServiceNowTicketValidator/DTOs/ServiceNowIncident.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/ServiceNowIncident.cs
@@ -2,8 +2,10 @@
 
 namespace ServiceNowTicketValidator.DTOs
 {
+    // There are more fields available. I trimmed out what I thought was most useful.
+    // Anything could be added back of course.
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    internal class Incident
+    internal class ServiceNowIncident
     {
         public string number { get; set; }
         public string state { get; set; }
@@ -12,5 +14,9 @@ namespace ServiceNowTicketValidator.DTOs
         public string opened_at { get; set; }
         public string resolved_at { get; set; }
         public string closed_at { get; set; }
+        public ServiceNowLink caller_id { get; set; }
+        public ServiceNowLink opened_by { get; set; }
+        public ServiceNowLink assigned_to { get; set; }
+        public ServiceNowLink cmdb_ci { get; set; }
     }
 }

--- a/Samples/ServiceNowTicketValidator/DTOs/ServiceNowLink.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/ServiceNowLink.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace ServiceNowTicketValidator.DTOs
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class ServiceNowLink
+    {
+        public string link { get; set; }
+        public string value { get; set; }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/DTOs/ServiceNowResult.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/ServiceNowResult.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ServiceNowTicketValidator.DTOs
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class ServiceNowResult<T> where T : class
+    {
+        public IEnumerable<T> result { get; set; }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/DTOs/ServiceNowSysUser.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/ServiceNowSysUser.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace ServiceNowTicketValidator.DTOs
+{
+    // There are more fields available. I trimmed out what I thought was most useful.
+    // Anything could be added back of course.
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class ServiceNowSysUser
+    {
+        public string sys_id { get; set; }
+        public string name { get; set; }
+        public string user_name { get; set; }
+        public string first_name { get; set; }
+        public string middle_name { get; set; }
+        public string last_name { get; set; }
+        public string email { get; set; }
+        public string manager { get; set; }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/DTOs/ServiceNowToken.cs
+++ b/Samples/ServiceNowTicketValidator/DTOs/ServiceNowToken.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ServiceNowTicketValidator.DTOs
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class ServiceNowToken
+    {
+        private int _expires_in;
+        public string access_token { get; set; }
+        public string refresh_token { get; set; }
+        public string scope { get; set; }
+        public string token_type { get; set; }
+        public int expires_in
+        {
+            get => _expires_in;
+            set
+            {
+                _expires_in = value;
+                ExpiresAt = DateTime.UtcNow.AddSeconds(value);
+            }
+        }
+        public DateTime ExpiresAt { get; set; }
+        public bool Expired => DateTime.UtcNow > ExpiresAt;
+    }
+}

--- a/Samples/ServiceNowTicketValidator/Program.cs
+++ b/Samples/ServiceNowTicketValidator/Program.cs
@@ -1,9 +1,44 @@
-﻿namespace ServiceNowTicketValidator
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Serilog;
+using Serilog.Events;
+using Topshelf;
+
+namespace ServiceNowTicketValidator
 {
-    internal class Program
+    internal static class Program
     {
         static void Main(string[] args)
         {
+            if (Environment.UserInteractive)
+                Log.Logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.ColoredConsole()
+                    .CreateLogger();
+            else
+            {
+                var loggingDirectory = ConfigUtils.ReadRequiredSettingFromAppConfig("LoggingDirectory", "logging directory");
+                if (!Path.IsPathRooted(loggingDirectory))
+                    loggingDirectory = Path.Combine(Assembly.GetEntryAssembly().Location, loggingDirectory);
+                Log.Logger = new LoggerConfiguration().WriteTo.RollingFile(
+                        Path.Combine(loggingDirectory, "ServiceNowTicketValidator-{Date}.log").ToString(),
+                        LogEventLevel.Debug)
+                    .CreateLogger();
+            }
+
+            HostFactory.Run(hostConfig =>
+            {
+                hostConfig.Service<ServiceNowTicketValidatorService>(service =>
+                {
+                    service.ConstructUsing(c => new ServiceNowTicketValidatorService());
+                    service.WhenStarted(s => s.Start());
+                    service.WhenStopped(s => s.Stop());
+                });
+                hostConfig.UseSerilog();
+                hostConfig.StartAutomaticallyDelayed();
+                hostConfig.SetDisplayName("ServiceNowTicketValidator");
+                hostConfig.SetServiceName("SvcNowTktV");
+                hostConfig.SetDescription("Simple ServiceNow ticket validation and access request approval engine.");
+            });
         }
     }
 }

--- a/Samples/ServiceNowTicketValidator/Program.cs
+++ b/Samples/ServiceNowTicketValidator/Program.cs
@@ -1,0 +1,9 @@
+﻿namespace ServiceNowTicketValidator
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/Properties/AssemblyInfo.cs
+++ b/Samples/ServiceNowTicketValidator/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceNowTicketValidator")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ServiceNowTicketValidator")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("be0c60e2-002e-42a0-a1d1-3bb9ae90d607")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Samples/ServiceNowTicketValidator/README.md
+++ b/Samples/ServiceNowTicketValidator/README.md
@@ -5,6 +5,8 @@ This is built using the SafeguardDotNet nuget package from nuget.org, not using 
 The current sample makes sure that the configuration item in the ticket matches the asset requested.
 It also makes sure that the requester is the same as the assignee on the ticket.
 
+The sample can be updated to modify the ticket validation logic in order to fit the needs of any organization using ServiceNow.
+
 This sample demonstrates:
 
 - thumbprint-based client certificate authentication from a Windows host (most secure method)

--- a/Samples/ServiceNowTicketValidator/README.md
+++ b/Samples/ServiceNowTicketValidator/README.md
@@ -1,0 +1,15 @@
+TopShelf service that can be run to perform legitimate ticket validation on ServiceNow tickets.
+
+This is built using the SafeguardDotNet nuget package from nuget.org, not using the source code from the repo.
+
+The current sample makes sure that the configuration item in the ticket matches the asset requested.
+It also makes sure that the requester is the same as the assignee on the ticket.
+
+This sample demonstrates:
+
+- thumbprint-based client certificate authentication from a Windows host (most secure method)
+- uses A2A for fetching credential to talk to ServiceNow
+- uses client certificate and standard Safeguard API connection to act as automated approver
+- uses persistent event listener to detect approval pending events
+- parameters are loaded from app.config
+- Serilog logging goes to a console when run interactively and to rolling files when installed as a service

--- a/Samples/ServiceNowTicketValidator/ServiceNowClient.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowClient.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Security;
+using OneIdentity.SafeguardDotNet;
+using RestSharp;
+using RestSharp.Authenticators;
+using Serilog;
+
+using Method = RestSharp.Method;
+
+namespace ServiceNowTicketValidator
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class ServiceNowResult<T> where T : class
+    {
+        public IEnumerable<T> result { get; set; }
+    }
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class Incident
+    {
+        public string number { get; set; }
+        public string state { get; set; }
+        public bool Active => active != "false";
+        public string active { get; set; }
+        public string opened_at { get; set; }
+        public string resolved_at { get; set; }
+        public string closed_at { get; set; }
+    }
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal class ServiceNowToken
+    {
+        private int _expires_in;
+        public string access_token { get; set; }
+        public string refresh_token { get; set; }
+        public string scope { get; set; }
+        public string token_type { get; set; }
+        public int expires_in
+        {
+            get => _expires_in;
+            set
+            {
+                _expires_in = value;
+                ExpiresAt = DateTime.UtcNow.AddSeconds(value);
+            }
+        }
+        public DateTime ExpiresAt { get; set; }
+        public bool Expired => DateTime.UtcNow > ExpiresAt;
+    }
+
+    internal class ServiceNowClient : IDisposable
+    {
+        private const string TokenAuthUriFormat = "{0}/oauth_token.do";
+        private const string IncidentByTicketNumberFormat = "api/now/table/incident?sysparm_query=number%3D{0}&sysparm_limit=1";
+
+        private readonly string _applicationUrl;
+        private readonly SecureString _clientSecret;
+        private readonly string _userName;
+        private readonly SecureString _password;
+        private ServiceNowToken _accessToken;
+        private RestClient _restClient;
+
+        public ServiceNowClient(string applicationUrl, SecureString clientSecret, string userName,
+            SecureString password)
+        {
+            _applicationUrl = applicationUrl;
+            _clientSecret = clientSecret.Copy();
+            _userName = userName;
+            _password = password.Copy();
+        }
+
+        public Incident GetIncident(string ticketNumber)
+        {
+            try
+            {
+                if (_restClient == null || _accessToken == null || _accessToken.Expired)
+                    _restClient = GetRestClient();
+                var request =
+                    new RestRequest($"api/now/table/incident?sysparm_query=number%3D{ticketNumber}&sysparm_limit=1",
+                        Method.GET);
+                request.AddHeader("Accept", "application/json");
+                if (!UseBasicAuth)
+                    request.AddHeader("Authorization", $"Bearer {_accessToken.access_token}");
+                var response = _restClient.Execute<ServiceNowResult<Incident>>(request);
+                return response?.Data?.result?.FirstOrDefault();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Unable to find incident for ticket number {ticketNumber}");
+                return null;
+            }
+        }
+
+        private bool UseBasicAuth => _clientSecret == null;
+
+        private RestClient GetRestClient()
+        {
+            var restClient = _restClient ?? new RestClient(_applicationUrl);
+            if (UseBasicAuth)
+                restClient.Authenticator = new HttpBasicAuthenticator(_userName, _password.ToInsecureString());
+            else
+                HandleOAuth();
+            return restClient;
+        }
+
+        private void HandleOAuth()
+        {
+            
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _clientSecret?.Dispose();
+                _password?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/ServiceNowClient.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowClient.cs
@@ -1,56 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security;
 using OneIdentity.SafeguardDotNet;
 using RestSharp;
 using RestSharp.Authenticators;
 using Serilog;
-
+using ServiceNowTicketValidator.DTOs;
 using Method = RestSharp.Method;
 
 namespace ServiceNowTicketValidator
 {
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    internal class ServiceNowResult<T> where T : class
-    {
-        public IEnumerable<T> result { get; set; }
-    }
-
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    internal class Incident
-    {
-        public string number { get; set; }
-        public string state { get; set; }
-        public bool Active => active != "false";
-        public string active { get; set; }
-        public string opened_at { get; set; }
-        public string resolved_at { get; set; }
-        public string closed_at { get; set; }
-    }
-
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    internal class ServiceNowToken
-    {
-        private int _expires_in;
-        public string access_token { get; set; }
-        public string refresh_token { get; set; }
-        public string scope { get; set; }
-        public string token_type { get; set; }
-        public int expires_in
-        {
-            get => _expires_in;
-            set
-            {
-                _expires_in = value;
-                ExpiresAt = DateTime.UtcNow.AddSeconds(value);
-            }
-        }
-        public DateTime ExpiresAt { get; set; }
-        public bool Expired => DateTime.UtcNow > ExpiresAt;
-    }
-
     internal class ServiceNowClient : IDisposable
     {
         private const string TokenAuthUriFormat = "{0}/oauth_token.do";
@@ -67,7 +26,7 @@ namespace ServiceNowTicketValidator
             SecureString password)
         {
             _applicationUrl = applicationUrl;
-            _clientSecret = clientSecret.Copy();
+            _clientSecret = clientSecret?.Copy();
             _userName = userName;
             _password = password.Copy();
         }

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.cs
@@ -1,25 +1,43 @@
 ﻿using System;
 using System.Security;
+using Serilog;
+using ServiceNowTicketValidator.DTOs;
 
 namespace ServiceNowTicketValidator
 {
+    internal enum ValidationResult
+    {
+        Ignore,
+        Approve,
+        Deny
+    }
+
     internal class ServiceNowTicketValidator : IDisposable
     {
         private readonly ServiceNowClient _client;
 
         public ServiceNowTicketValidator(string dnsName, SecureString clientSecret, string userName, SecureString password)
         {
+            // This ticket validator is specifically written for working with ServiceNow, but it could easily be modified
+            // to support any ticketing system that you would like, even ticket systems that are not REST API based.
+            // Just use a different client here and use a different ticket number lookup below.
             _client = new ServiceNowClient($"https://{dnsName}/", clientSecret, userName, password);
         }
 
-        public bool CheckTicket(string ticketNumber)
+        public ValidationResult CheckTicket(string ticketNumber, AccessRequest accessRequest)
         {
             var incident = _client.GetIncident(ticketNumber);
+            if (incident == null)
+            {
+                Log.Information("Unable to locate incident {TicketNumber}, ignoring", ticketNumber);
+                return ValidationResult.Ignore;
+            }
+
+            // If you would like to change the validation logic of a ticket this is where you would put your code changes.
+            // Just delete the logic that is here and replace it with your own.
 
 
-
-
-            return false;
+            return ValidationResult.Ignore;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.cs
@@ -5,14 +5,20 @@ namespace ServiceNowTicketValidator
 {
     internal class ServiceNowTicketValidator : IDisposable
     {
-        public ServiceNowTicketValidator(string userName, SecureString password)
+        private readonly ServiceNowClient _client;
+
+        public ServiceNowTicketValidator(string dnsName, SecureString clientSecret, string userName, SecureString password)
         {
-            // TODO:
+            _client = new ServiceNowClient($"https://{dnsName}/", clientSecret, userName, password);
         }
 
         public bool CheckTicket(string ticketNumber)
         {
-            // TODO:
+            var incident = _client.GetIncident(ticketNumber);
+
+
+
+
             return false;
         }
 
@@ -20,7 +26,7 @@ namespace ServiceNowTicketValidator
         {
             if (disposing)
             {
-                // TODO:
+                _client?.Dispose();
             }
         }
 

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Security;
+
+namespace ServiceNowTicketValidator
+{
+    internal class ServiceNowTicketValidator : IDisposable
+    {
+        public ServiceNowTicketValidator(string userName, SecureString password)
+        {
+            // TODO:
+        }
+
+        public bool CheckTicket(string ticketNumber)
+        {
+            // TODO:
+            return false;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // TODO:
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BE0C60E2-002E-42A0-A1D1-3BB9AE90D607}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ServiceNowTicketValidator</RootNamespace>
+    <AssemblyName>ServiceNowTicketValidator</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.SignalR.Client.2.3.0\lib\net45\Microsoft.AspNet.SignalR.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="OneIdentity.SafeguardDotNet, Version=2.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\OneIdentity.SafeguardDotNet.2.3.1\lib\netstandard2.0\OneIdentity.SafeguardDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=106.4.2.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>packages\RestSharp.106.4.2\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>packages\Serilog.2.7.1\lib\net46\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.ColoredConsole, Version=3.0.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>packages\Serilog.Sinks.ColoredConsole.3.0.1\lib\net45\Serilog.Sinks.ColoredConsole.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Configuration.Install" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Topshelf, Version=4.1.0.172, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>packages\Topshelf.4.1.0\lib\net452\Topshelf.dll</HintPath>
+    </Reference>
+    <Reference Include="Topshelf.Serilog, Version=4.1.0.172, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>packages\Topshelf.Serilog.4.1.0\lib\net452\Topshelf.Serilog.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceNowTicketValidator.cs" />
+    <Compile Include="ServiceNowTicketValidatorService.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
@@ -41,8 +41,8 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OneIdentity.SafeguardDotNet, Version=2.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\OneIdentity.SafeguardDotNet.2.3.1\lib\netstandard2.0\OneIdentity.SafeguardDotNet.dll</HintPath>
+    <Reference Include="OneIdentity.SafeguardDotNet, Version=2.3.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\OneIdentity.SafeguardDotNet.2.3.2\lib\netstandard2.0\OneIdentity.SafeguardDotNet.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=106.4.2.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>packages\RestSharp.106.4.2\lib\net452\RestSharp.dll</HintPath>
@@ -82,6 +82,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigUtils.cs" />
+    <Compile Include="DTOs\AccessRequest.cs" />
+    <Compile Include="DTOs\AccessRequestApprovalPendingEvent.cs" />
+    <Compile Include="DTOs\Incident.cs" />
+    <Compile Include="DTOs\ServiceNowResult.cs" />
+    <Compile Include="DTOs\ServiceNowToken.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServiceNowClient.cs" />
@@ -89,7 +94,9 @@
     <Compile Include="ServiceNowTicketValidatorService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
@@ -81,8 +81,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConfigUtils.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceNowClient.cs" />
     <Compile Include="ServiceNowTicketValidator.cs" />
     <Compile Include="ServiceNowTicketValidatorService.cs" />
   </ItemGroup>

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
@@ -84,8 +84,11 @@
     <Compile Include="ConfigUtils.cs" />
     <Compile Include="DTOs\AccessRequest.cs" />
     <Compile Include="DTOs\AccessRequestApprovalPendingEvent.cs" />
-    <Compile Include="DTOs\Incident.cs" />
+    <Compile Include="DTOs\ServiceNowCmdbCi.cs" />
+    <Compile Include="DTOs\ServiceNowIncident.cs" />
+    <Compile Include="DTOs\ServiceNowLink.cs" />
     <Compile Include="DTOs\ServiceNowResult.cs" />
+    <Compile Include="DTOs\ServiceNowSysUser.cs" />
     <Compile Include="DTOs\ServiceNowToken.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.sln
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceNowTicketValidator", "ServiceNowTicketValidator.csproj", "{BE0C60E2-002E-42A0-A1D1-3BB9AE90D607}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BE0C60E2-002E-42A0-A1D1-3BB9AE90D607}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE0C60E2-002E-42A0-A1D1-3BB9AE90D607}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE0C60E2-002E-42A0-A1D1-3BB9AE90D607}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE0C60E2-002E-42A0-A1D1-3BB9AE90D607}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {48F59535-AC23-41B5-B87E-49049D2506E5}
+	EndGlobalSection
+EndGlobal

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidatorService.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidatorService.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Configuration;
+﻿using System.Configuration;
 using System.Security;
 using OneIdentity.SafeguardDotNet;
 using OneIdentity.SafeguardDotNet.Event;
-using Serilog;
 
 namespace ServiceNowTicketValidator
 {
@@ -81,11 +79,13 @@ namespace ServiceNowTicketValidator
             _validator = new ServiceNowTicketValidator(_serviceNowDnsName, _serviceNowClientSecret, _serviceNowUserName,
                 _serviceNowPassword);
             _eventListener.RegisterEventHandler("AccessRequestPendingApproval", HandlePendingApprovalNotification);
+
+            _eventListener.Start();
         }
 
         public void Stop()
         {
-            // TODO: stop listening
+            _eventListener.Stop();
 
             _eventListener?.Dispose();
             _connection?.Dispose();
@@ -93,7 +93,8 @@ namespace ServiceNowTicketValidator
             _validator?.Dispose();
             _eventListener = null;
             _connection = null;
-
+            _serviceNowPassword = null;
+            _validator = null;
         }
     }
 }

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidatorService.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidatorService.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Configuration;
+using System.Security;
+using OneIdentity.SafeguardDotNet;
+using OneIdentity.SafeguardDotNet.Event;
+using Serilog;
+
+namespace ServiceNowTicketValidator
+{
+    internal class ServiceNowTicketValidatorService
+    {
+        private readonly string _safeguardAddress;
+        private readonly string _safeguardClientCertificateThumbprint;
+        private readonly int _safeguardApiVersion;
+        private readonly bool _safeguardIgnoreSsl;
+        private readonly string _serviceNowUserName;
+        private readonly SecureString _safeguardA2AApiKeyForServiceNowPassword;
+        private readonly string _loggingDirectory;
+
+        private SecureString _serviceNowPassword;
+        private ISafeguardEventListener _eventListener;
+        private ISafeguardConnection _connection;
+        private ServiceNowTicketValidator _validator;
+
+        public ServiceNowTicketValidatorService()
+        {
+            _safeguardAddress =
+                ReadRequiredSettingFromAppConfig("SafeguardAddress", "Safeguard appliance network address");
+            _safeguardClientCertificateThumbprint =
+                ReadRequiredSettingFromAppConfig("SafeguardClientCertificateThumbprint",
+                    "Safeguard client certificate thumbprint");
+            _safeguardApiVersion =
+                int.Parse(ReadRequiredSettingFromAppConfig("SafeguardApiVersion", "Safeguard API version"));
+            _safeguardIgnoreSsl = bool.Parse(ConfigurationManager.AppSettings["SafeguardIgnoreSsl"]);
+            _serviceNowUserName = ReadRequiredSettingFromAppConfig("ServiceNowUserName", "ServiceNow user name");
+            _safeguardA2AApiKeyForServiceNowPassword = ReadRequiredSettingFromAppConfig(
+                    "SafeguardA2AApiKeyForServiceNowPassword",
+                    "Safeguard A2A API key for retrieving ServiceNow password")
+                .ToSecureString();
+            _loggingDirectory = ReadRequiredSettingFromAppConfig("LoggingDirectory", "logging directory");
+        }
+
+        private void HandlePendingApprovalNotification(string eventName, string eventBody)
+        {
+            // TODO: check to be sure it has a ticket number (assume ServiceNow / check for INC)
+
+            var ticketNumber = "";
+
+            // TODO: bail early if no ticket number
+
+            // TODO: get relevant info for approve or deny
+
+            var accessRequestId = "";
+
+            if (_connection.GetAccessTokenLifetimeRemaining() == 0)
+                _connection.RefreshAccessToken();
+
+            if (_validator.CheckTicket(ticketNumber))
+                _connection.InvokeMethod(Service.Core, Method.Post, $"AccessRequests/{accessRequestId}/Approve");
+            else
+                _connection.InvokeMethod(Service.Core, Method.Post, $"AccessRequests/{accessRequestId}/Deny");
+        }
+
+        public void Start()
+        {
+            _eventListener = Safeguard.Event.GetPersistentEventListener(_safeguardAddress,
+                _safeguardClientCertificateThumbprint, _safeguardApiVersion, _safeguardIgnoreSsl);
+            _connection = Safeguard.Connect(_safeguardAddress, _safeguardClientCertificateThumbprint,
+                _safeguardApiVersion, _safeguardIgnoreSsl);
+            using (var a2AContext = Safeguard.A2A.GetContext(_safeguardAddress, _safeguardClientCertificateThumbprint,
+                _safeguardApiVersion, _safeguardIgnoreSsl))
+            {
+                _serviceNowPassword = a2AContext.RetrievePassword(_safeguardA2AApiKeyForServiceNowPassword);
+            }
+            _validator = new ServiceNowTicketValidator(_serviceNowUserName, _serviceNowPassword);
+            _eventListener.RegisterEventHandler("AccessRequestPendingApproval", HandlePendingApprovalNotification);
+        }
+
+        public void Stop()
+        {
+            // TODO: stop listening
+
+            _eventListener?.Dispose();
+            _connection?.Dispose();
+            _serviceNowPassword?.Dispose();
+            _safeguardA2AApiKeyForServiceNowPassword?.Dispose();
+            _validator?.Dispose();
+        }
+
+        private static string ReadRequiredSettingFromAppConfig(string key, string description)
+        {
+            try
+            {
+                var value = ConfigurationManager.AppSettings[key];
+                if (!string.IsNullOrEmpty(value))
+                    return value;
+                Log.Error($"{key} is required in App.Config");
+                throw new Exception($"Unable to start SlackBotService with empty {description}.");
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                Log.Error(ex, $"{key} is required in App.Config");
+                throw new Exception($"Unable to start SlackBotService without {description}.", ex);
+            }
+        }
+    }
+}

--- a/Samples/ServiceNowTicketValidator/app.config
+++ b/Samples/ServiceNowTicketValidator/app.config
@@ -18,7 +18,7 @@
     <add key="SafeguardClientCertificateThumbprint" value="" />
     <add key="SafeguardApiVersion" value="2" />
     <add key="SafeguardIgnoreSsl" value="true" />
-    <add key="ServiceNowNetworkAddress" value="" />
+    <add key="ServiceNowDnsName" value="" />
     <add key="ServiceNowClientSecret" value="" />
     <add key="ServiceNowUserName" value="" />
     <add key="SafeguardA2AApiKeyForServiceNowPassword" value="" />

--- a/Samples/ServiceNowTicketValidator/app.config
+++ b/Samples/ServiceNowTicketValidator/app.config
@@ -18,6 +18,8 @@
     <add key="SafeguardClientCertificateThumbprint" value="" />
     <add key="SafeguardApiVersion" value="2" />
     <add key="SafeguardIgnoreSsl" value="true" />
+    <add key="ServiceNowNetworkAddress" value="" />
+    <add key="ServiceNowClientSecret" value="" />
     <add key="ServiceNowUserName" value="" />
     <add key="SafeguardA2AApiKeyForServiceNowPassword" value="" />
     <add key="LoggingDirectory" value="Logs" />

--- a/Samples/ServiceNowTicketValidator/app.config
+++ b/Samples/ServiceNowTicketValidator/app.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog.Sinks.Console" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.1.0" newVersion="3.1.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <appSettings>
+    <add key="SafeguardAddress" value="" />
+    <add key="SafeguardClientCertificateThumbprint" value="" />
+    <add key="SafeguardApiVersion" value="2" />
+    <add key="SafeguardIgnoreSsl" value="true" />
+    <add key="ServiceNowUserName" value="" />
+    <add key="SafeguardA2AApiKeyForServiceNowPassword" value="" />
+    <add key="LoggingDirectory" value="Logs" />
+  </appSettings>
+</configuration>

--- a/Samples/ServiceNowTicketValidator/packages.config
+++ b/Samples/ServiceNowTicketValidator/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.AspNet.SignalR.Client" version="2.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
-  <package id="OneIdentity.SafeguardDotNet" version="2.3.1" targetFramework="net462" />
+  <package id="OneIdentity.SafeguardDotNet" version="2.3.2" targetFramework="net462" />
   <package id="RestSharp" version="106.4.2" targetFramework="net462" />
   <package id="Serilog" version="2.7.1" targetFramework="net462" />
   <package id="Serilog.Sinks.ColoredConsole" version="3.0.1" targetFramework="net462" />

--- a/Samples/ServiceNowTicketValidator/packages.config
+++ b/Samples/ServiceNowTicketValidator/packages.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.SignalR.Client" version="2.3.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
+  <package id="OneIdentity.SafeguardDotNet" version="2.3.1" targetFramework="net462" />
+  <package id="RestSharp" version="106.4.2" targetFramework="net462" />
+  <package id="Serilog" version="2.7.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.ColoredConsole" version="3.0.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net462" />
+  <package id="Topshelf" version="4.1.0" targetFramework="net462" />
+  <package id="Topshelf.Serilog" version="4.1.0" targetFramework="net462" />
+</packages>

--- a/Test/SafeguardDotNetEventTool/Program.cs
+++ b/Test/SafeguardDotNetEventTool/Program.cs
@@ -195,7 +195,7 @@ namespace SafeguardDotNetEventTool
                     using (var listener = CreatePersistentListener(opts))
                         RunListener(listener);
                 }
-                else if (string.IsNullOrEmpty(opts.ApiKey))
+                else if (!string.IsNullOrEmpty(opts.ApiKey))
                 {
                     using (var listener = CreateA2AListener(opts))
                         RunListener(listener);

--- a/Test/SafeguardDotNetEventTool/ToolOptions.cs
+++ b/Test/SafeguardDotNetEventTool/ToolOptions.cs
@@ -48,7 +48,8 @@ namespace SafeguardDotNetEventTool
             HelpText = "Safeguard event to listen for")]
         public string Event { get; set; }
 
-        [Option('P', "Persistent", HelpText = "Use persistent listeners")]
+        [Option('P', "Persistent", Required = false,
+            HelpText = "Use persistent listeners")]
         public bool Persistent { get; set; }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ configuration: Release
 before_build:
 - ps: '& .\appveyor-prebuild.ps1'
 build:
+  project: SafeguardDotNet.sln
   publish_nuget: true
   parallel: true
   verbosity: normal


### PR DESCRIPTION
TopShelf service that can be run to perform legitimate ticket validation on ServiceNow tickets.

This is built using the SafeguardDotNet nuget package from nuget.org, not using the source code from the repo.

The current sample makes sure that the configuration item in the ticket matches the asset requested.
It also makes sure that the requester is the same as the assignee on the ticket.

This sample demonstrates:
- thumbprint-based client certificate authentication from a Windows host (most secure method)
- uses A2A for fetching credential to talk to ServiceNow
- uses client certificate and standard Safeguard API connection to act as automated approver
- uses persistent event listener to detect approval pending events
- parameters are loaded from app.config
- Serilog logging goes to a console when run interactively and to rolling files when installed as a service