### PR TITLE
Listener and logout improvements

### DIFF
--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -20,14 +20,25 @@ namespace OneIdentity.SafeguardDotNet.A2A
         /// <summary>
         /// Gets an A2A event listener. The handler passed in will be registered for the AssetAccountPasswordUpdated
         /// event, which is the only one supported in A2A. You just have to call Start(). The event listener returned
-        /// by this method will not automatically recover from a SignalR timeout which occurs when there is a 30+
+        /// by this method WILL NOT automatically recover from a SignalR timeout which occurs when there is a 30+
         /// second outage. To get an event listener that supports recovering from longer term outages, please use
-        /// Safeguard.A2A.Event to request a persistent event listener.
+        /// GetPersistentEventListener() to request a persistent event listener.
         /// </summary>
         /// <param name="apiKey">API key corresponding to the configured account to listen for.</param>
         /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
         /// <returns>The event listener.</returns>
-        ISafeguardEventListener GetEventListener(SecureString apiKey, SafeguardEventHandler handler);
+        ISafeguardEventListener GetA2AEventListener(SecureString apiKey, SafeguardEventHandler handler);
+
+        /// <summary>
+        /// Gets a persistent A2A event listener. The handler passed in will be registered for the
+        /// AssetAccountPasswordUpdated event, which is the only one supported in A2A. You just have to call Start().
+        /// The event listener returned by this method will not automatically recover from a SignalR timeout which
+        /// occurs when there is a 30+ second outage.
+        /// </summary>
+        /// <param name="apiKey">API key corresponding to the configured account to listen for.</param>
+        /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+        /// <returns>The event listener.</returns>
+        ISafeguardEventListener GetPersistentA2AEventListener(SecureString apiKey, SafeguardEventHandler handler);
 
         /// <summary>
         /// Creates an access request on behalf of another user using Safeguard A2A.

--- a/SafeguardDotNet/A2A/SafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/SafeguardA2AContext.cs
@@ -82,7 +82,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
             var eventListener = new SafeguardEventListener($"https://{_networkAddress}/service/a2a", _clientCertificate,
                 apiKey, _ignoreSsl);
             eventListener.RegisterEventHandler("AssetAccountPasswordUpdated", handler);
-            Log.Information("Event listener successfully created for Safeguard A2A context.");
+            Log.Debug("Event listener successfully created for Safeguard A2A context.");
             return eventListener;
         }
 

--- a/SafeguardDotNet/Authentication/AccessTokenAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/AccessTokenAuthenticator.cs
@@ -17,6 +17,11 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             throw new SafeguardDotNetException("Original authentication was with access token unable to refresh, Error: Unsupported operation");
         }
 
+        public override object Clone()
+        {
+            throw new SafeguardDotNetException("Access token authenticators are not cloneable");
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (_disposed || !disposing)

--- a/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
@@ -16,6 +16,11 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             throw new SafeguardDotNetException("Anonymous connection cannot be used to get an API access token, Error: Unsupported operation");
         }
 
+        public override object Clone()
+        {
+            throw new SafeguardDotNetException("Anonymous authenticators are not cloneable");
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (_disposed || !disposing)

--- a/SafeguardDotNet/Authentication/AuthenticatorBase.cs
+++ b/SafeguardDotNet/Authentication/AuthenticatorBase.cs
@@ -6,7 +6,7 @@ using RestSharp;
 
 namespace OneIdentity.SafeguardDotNet.Authentication
 {
-    internal abstract class AuthenticatorBase : IAuthenticationMechanism
+    internal abstract class AuthenticatorBase : IAuthenticationMechanism, ICloneable
     {
         private bool _disposed;
 
@@ -47,6 +47,12 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         public bool HasAccessToken()
         {
             return AccessToken != null;
+        }
+
+        public void ClearAccessToken()
+        {
+            AccessToken?.Dispose();
+            AccessToken = null;
         }
 
         public SecureString GetAccessToken()
@@ -106,6 +112,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
 
         protected abstract SecureString GetRstsTokenInternal();
 
+        public abstract object Clone();
+
         public void Dispose()
         {
             Dispose(true);
@@ -118,7 +126,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
                 return;
             try
             {
-                AccessToken?.Dispose();
+               ClearAccessToken();
             }
             finally
             {

--- a/SafeguardDotNet/Authentication/CertificateAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/CertificateAuthenticator.cs
@@ -56,6 +56,15 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             return jObject.GetValue("access_token").ToString().ToSecureString();
         }
 
+        public override object Clone()
+        {
+            var auth = !string.IsNullOrEmpty(_certificateThumbprint)
+                ? new CertificateAuthenticator(NetworkAddress, _certificateThumbprint, ApiVersion, IgnoreSsl)
+                : new CertificateAuthenticator(NetworkAddress, _certificatePath, _certificatePassword, ApiVersion, IgnoreSsl);
+            auth.AccessToken = AccessToken.Copy();
+            return auth;
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (_disposed || !disposing)

--- a/SafeguardDotNet/Authentication/IAuthenticationMechanism.cs
+++ b/SafeguardDotNet/Authentication/IAuthenticationMechanism.cs
@@ -3,7 +3,7 @@ using System.Security;
 
 namespace OneIdentity.SafeguardDotNet.Authentication
 {
-    internal interface IAuthenticationMechanism : IDisposable
+    internal interface IAuthenticationMechanism : IDisposable, ICloneable
     {
         string NetworkAddress { get; }
 
@@ -12,6 +12,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         bool IgnoreSsl { get; }
 
         bool HasAccessToken();
+
+        void ClearAccessToken();
 
         SecureString GetAccessToken();
 

--- a/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
@@ -24,7 +24,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             if (string.IsNullOrEmpty(_provider))
                 _providerScope = "rsts:sts:primaryproviderid:local";
             _username = username;
-            _password = password;
+            _password = password.Copy();
         }
 
         private void ResolveProviderToScope()
@@ -108,6 +108,16 @@ namespace OneIdentity.SafeguardDotNet.Authentication
                                                    $"{response.StatusCode} {response.Content}", response.Content);
             var jObject = JObject.Parse(response.Content);
             return jObject.GetValue("access_token").ToString().ToSecureString();
+        }
+
+        public override object Clone()
+        {
+            var auth =
+                new PasswordAuthenticator(NetworkAddress, _provider, _username, _password, ApiVersion, IgnoreSsl)
+                {
+                    AccessToken = AccessToken.Copy()
+                };
+            return auth;
         }
 
         protected override void Dispose(bool disposing)

--- a/SafeguardDotNet/Event/EventHandlerRegistry.cs
+++ b/SafeguardDotNet/Event/EventHandlerRegistry.cs
@@ -17,7 +17,7 @@ namespace OneIdentity.SafeguardDotNet.Event
         {
             if (!_delegateRegistry.ContainsKey(eventName))
             {
-                Log.Information("No handlers registered for event {Event}", eventName);
+                Log.Debug("No handlers registered for event {Event}", eventName);
                 return;
             }
 

--- a/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
@@ -22,7 +22,7 @@ namespace OneIdentity.SafeguardDotNet.Event
         protected override SafeguardEventListener ReconnectEventListener()
         {
             // passing in a bogus handler because it will be overridden in PersistentSafeguardEventListenerBase
-            return (SafeguardEventListener) _a2AContext.GetEventListener(_apiKey, (name, body) => { });
+            return (SafeguardEventListener) _a2AContext.GetA2AEventListener(_apiKey, (name, body) => { });
         }
 
         protected override void Dispose(bool disposing)

--- a/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
@@ -16,7 +16,7 @@ namespace OneIdentity.SafeguardDotNet.Event
             _a2AContext = a2AContext;
             _apiKey = apiKey.Copy();
             RegisterEventHandler("AssetAccountPasswordUpdated", handler);
-            Log.Information("Persistent A2A event listener successfully created.");
+            Log.Debug("Persistent A2A event listener successfully created.");
         }
 
         protected override SafeguardEventListener ReconnectEventListener()

--- a/SafeguardDotNet/Event/PersistentSafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardEventListener.cs
@@ -11,7 +11,7 @@ namespace OneIdentity.SafeguardDotNet.Event
         public PersistentSafeguardEventListener(ISafeguardConnection connection)
         {
             _connection = connection;
-            Log.Information("Persistent event listener successfully created.");
+            Log.Debug("Persistent event listener successfully created.");
         }
 
         protected override SafeguardEventListener ReconnectEventListener()

--- a/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardEventListenerBase.cs
@@ -41,7 +41,7 @@ namespace OneIdentity.SafeguardDotNet.Event
                     try
                     {
                         _eventListener?.Dispose();
-                        Log.Information("Attempting to connect and start internal event listener.");
+                        Log.Debug("Attempting to connect and start internal event listener.");
                         _eventListener = ReconnectEventListener();
                         _eventListener.SetEventHandlerRegistry(_eventHandlerRegistry);
                         _eventListener.Start();
@@ -62,7 +62,7 @@ namespace OneIdentity.SafeguardDotNet.Event
                 _reconnectCancel = null;
                 _reconnectTask = null;
                 if (!task.IsFaulted)
-                    Log.Information("Internal event listener successfully connected and started.");
+                    Log.Debug("Internal event listener successfully connected and started.");
             });
         }
 

--- a/SafeguardDotNet/ISafeguardConnection.cs
+++ b/SafeguardDotNet/ISafeguardConnection.cs
@@ -11,14 +11,14 @@ namespace OneIdentity.SafeguardDotNet
     public interface ISafeguardConnection : IDisposable
     {
         /// <summary>
-        /// Number of minutes remaining in the lifetime of the API access token.
+        /// Number of minutes remaining in the lifetime of the Safeguard API access token.
         /// </summary>
         /// <returns></returns>
         int GetAccessTokenLifetimeRemaining();
 
         /// <summary>
-        /// Use the underlying credentials used to initial create the connection to request a
-        /// new API access token.
+        /// Request a new Safeguard API access token with the underlying credentials used to
+        /// initially create the connection.
         /// </summary>
         void RefreshAccessToken();
 
@@ -56,12 +56,30 @@ namespace OneIdentity.SafeguardDotNet
         /// <summary>
         /// Gets a Safeguard event listener. You will need to call the RegisterEventHandler()
         /// method to establish callbacks. Then, you just have to call Start().  Call Stop()
-        /// when you are finished. The event listener returned by this method will not
+        /// when you are finished. The event listener returned by this method WILL NOT
         /// automatically recover from a SignalR timeout which occurs when there is a 30+
         /// second outage. To get an event listener that supports recovering from longer term
-        /// outages, please use Safeguard.Event to request a persistent event listener.
+        /// outages, please use GetPersistentEventListener() to request a persistent event
+        /// listener.
         /// </summary>
         /// <returns>The event listener.</returns>
         ISafeguardEventListener GetEventListener();
+
+        /// <summary>
+        /// Gets a persistent Safeguard event listener. You will need to call the
+        /// RegisterEventHandler() method to establish callbacks. Then, you just have to
+        /// call Start().  Call Stop() when you are finished. The event listener returned
+        /// by this method WILL automatically recover from a SignalR timeout which occurs
+        /// when there is a 30+ second outage.
+        /// </summary>
+        /// <returns>The persistent event listener.</returns>
+        ISafeguardEventListener GetPersistentEventListener();
+
+        /// <summary>
+        /// Call Safeguard API to invalidate current access token and clear its value from
+        /// the connection.  In order to continue using the connection you will need to call
+        /// RefreshAccessToken().
+        /// </summary>
+        void LogOut();
     }
 }

--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -154,7 +154,7 @@ namespace OneIdentity.SafeguardDotNet
             if (_authenticationMechanism.GetType() == typeof(PasswordAuthenticator) ||
                 _authenticationMechanism.GetType() == typeof(CertificateAuthenticator))
             {
-                return new PersistentSafeguardEventListener(this.Clone() as ISafeguardConnection);
+                return new PersistentSafeguardEventListener(Clone() as ISafeguardConnection);
             }
             throw new SafeguardDotNetException(
                 $"Unable to create persistent event listener from {_authenticationMechanism.GetType()}");

--- a/Test/SafeguardDotNetEventTool/Program.cs
+++ b/Test/SafeguardDotNetEventTool/Program.cs
@@ -120,7 +120,7 @@ namespace SafeguardDotNetEventTool
         {
             using (var context = CreateA2AContext(opts))
             {
-                return context.GetEventListener(opts.ApiKey.ToSecureString(),
+                return context.GetA2AEventListener(opts.ApiKey.ToSecureString(),
                     (name, body) => { Log.Information("Received A2A Event: {EventBody}", body); });
             }
         }

--- a/Test/SafeguardDotNetTool/Program.cs
+++ b/Test/SafeguardDotNetTool/Program.cs
@@ -80,6 +80,8 @@ namespace SafeguardDotNetTool
 
                 var responseBody = connection.InvokeMethod(opts.Service, opts.Method, opts.RelativeUrl, opts.Body);
                 Log.Information(responseBody);
+
+                connection.LogOut();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Added convenience methods for creating persistent event listeners from SafeguardConnection and SafeguardA2AContext objects
- Added the ability to log out an existing SafeguardConnection, which invalidates and cleans up the Safeguard API access token
- Reduced the log levels in the library to more appropriate levels--some informational messages should have actually been debug