### PR TITLE
Null check the password in Clone

### DIFF
--- a/SafeguardDotNet/CertificateContext.cs
+++ b/SafeguardDotNet/CertificateContext.cs
@@ -33,7 +33,7 @@ namespace OneIdentity.SafeguardDotNet
             {
                 Thumbprint = Thumbprint,
                 FilePath = FilePath,
-                Password = Password.Copy()
+                Password = Password?.Copy()
             };
             clone.Certificate = clone.Thumbprint != null
                 ? CertificateUtilities.GetClientCertificateFromStore(Thumbprint)


### PR DESCRIPTION
Unit testing this proved more convoluted than I thought, so I'm just committing the bug fix.