### PR TITLE
Add support for A2A credential retrieval API key discovery

### DIFF
--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Security;
 using OneIdentity.SafeguardDotNet.Event;
 
@@ -10,6 +11,13 @@ namespace OneIdentity.SafeguardDotNet.A2A
     /// </summary>
     public interface ISafeguardA2AContext : IDisposable
     {
+        /// <summary>
+        /// Retrieves the list of retrievable accounts for this A2A context.  Listing the retrievable accounts is a
+        /// new feature for Safeguard v2.8+, and it needs to be enabled in the A2A configuration.
+        /// </summary>
+        /// <returns>A list of retrievable accounts.</returns>
+        IList<A2ARetrievableAccount> GetRetrievableAccounts();
+
         /// <summary>
         /// Retrieves a password using Safeguard A2A.
         /// </summary>

--- a/SafeguardDotNet/SafeguardDotNet.csproj
+++ b/SafeguardDotNet/SafeguardDotNet.csproj
@@ -33,9 +33,11 @@ Updates:
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="RestSharp" Version="106.6.9" />
     <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/SafeguardDotNet/SafeguardDotNetTypes.cs
+++ b/SafeguardDotNet/SafeguardDotNetTypes.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
+using System.Security;
+using Newtonsoft.Json;
 
 namespace OneIdentity.SafeguardDotNet
 {
@@ -42,8 +45,34 @@ namespace OneIdentity.SafeguardDotNet
     /// </summary>
     public class FullResponse
     {
-        public HttpStatusCode StatusCode;
-        public IDictionary<string, string> Headers;
-        public string Body;
+        public HttpStatusCode StatusCode { get; set; }
+        public IDictionary<string, string> Headers { get; set; }
+        public string Body { get; set; }
+    }
+
+
+    public class A2ARetrievableAccount : IDisposable
+    {
+        public string ApplicationName { get; set; }
+        public string Description { get; set; }
+        public bool Disabled { get; set; }
+        public SecureString ApiKey { get; set; }
+        public int AssetId { get; set; }
+        public string AssetName { get; set; }
+        public int AccountId { get; set; }
+        public string AccountName { get; set; }
+        public string DomainName { get; set; }
+        public string AccountType { get; set; }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+
+        public void Dispose()
+        {
+            ApiKey?.Dispose();
+            ApiKey = null;
+        }
     }
 }

--- a/Test/SafeguardDotNetA2aTool/Program.cs
+++ b/Test/SafeguardDotNetA2aTool/Program.cs
@@ -77,8 +77,19 @@ namespace SafeguardDotNetA2aTool
 
                 using (var context = CreateA2AContext(opts))
                 {
-                    var responseBody = context.RetrievePassword(opts.ApiKey.ToSecureString());
-                    Log.Information(responseBody.ToInsecureString());
+                    if (opts.ApiKey.Equals("?"))
+                    {
+                        var responseBody = context.GetRetrievableAccounts();
+                        foreach (var obj in responseBody)
+                        {
+                            Log.Information(obj.ToString());
+                        }
+                    }
+                    else
+                    {
+                        var responseBody = context.RetrievePassword(opts.ApiKey.ToSecureString());
+                        Log.Information(responseBody.ToInsecureString());
+                    }
                 }
             }
             catch (Exception ex)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.7.0-release-{build}
+version: 2.8.0-dev-{build}
 image: Visual Studio 2017
 configuration: Release
 before_build:


### PR DESCRIPTION
In Safeguard 2.8, A2A registrations are made optionally visible to the calling certificate user.  A new method on IA2AContext can get information on all of the accounts that it can request.