### PR TITLE
Fix anonymous authentication

### DIFF
--- a/SafeguardDotNet.sln
+++ b/SafeguardDotNet.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SafeguardDotNet.GuiLogin", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SafeguardDotNetGuiTester", "Test\SafeguardDotNetGuiTester\SafeguardDotNetGuiTester.csproj", "{3298668C-7255-45E9-806C-111ED4DFB800}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{DD89D86B-68DA-4EB0-8EBC-60DE3DC2B084}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,6 +56,13 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A1C31631-3433-415B-81D5-3C9BC80710AC} = {DD89D86B-68DA-4EB0-8EBC-60DE3DC2B084}
+		{0852DDE0-8C16-4C29-B49F-8E67A2993078} = {DD89D86B-68DA-4EB0-8EBC-60DE3DC2B084}
+		{741143E4-C1AB-450C-8CCA-11225D037548} = {DD89D86B-68DA-4EB0-8EBC-60DE3DC2B084}
+		{37DC1680-E01E-4D39-8D5B-E2A0D908EB33} = {DD89D86B-68DA-4EB0-8EBC-60DE3DC2B084}
+		{3298668C-7255-45E9-806C-111ED4DFB800} = {DD89D86B-68DA-4EB0-8EBC-60DE3DC2B084}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D9CB73C2-C8BA-4198-AC5A-583C98326F2D}

--- a/SafeguardDotNet/Authentication/AccessTokenAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/AccessTokenAuthenticator.cs
@@ -15,6 +15,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             AccessToken = accessToken.Copy();
         }
 
+        public override string Id => "AccessToken";
+
         protected override SecureString GetRstsTokenInternal()
         {
             throw new SafeguardDotNetException("Original authentication was with access token unable to refresh, Error: Unsupported operation");

--- a/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
@@ -11,6 +11,10 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         {
         }
 
+        public override string Id => "Anonymous";
+
+        public override bool IsAnonymous => true;
+
         protected override SecureString GetRstsTokenInternal()
         {
             throw new SafeguardDotNetException("Anonymous connection cannot be used to get an API access token, Error: Unsupported operation");

--- a/SafeguardDotNet/Authentication/AuthenticatorBase.cs
+++ b/SafeguardDotNet/Authentication/AuthenticatorBase.cs
@@ -37,12 +37,15 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             }
         }
 
+        public abstract string Id { get; }
+
         public string NetworkAddress { get; }
 
         public int ApiVersion { get; }
 
         public bool IgnoreSsl { get; }
 
+        public virtual bool IsAnonymous => false;
 
         public bool HasAccessToken()
         {
@@ -103,7 +106,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
                     throw new SafeguardDotNetException($"Unable to connect to web service {CoreClient.BaseUrl}, Error: " +
                                                        response.ErrorMessage);
                 if (!response.IsSuccessful)
-                    throw new SafeguardDotNetException("Error exchanging RSTS token for Safeguard API access token, Error: " +
+                    throw new SafeguardDotNetException($"Error exchanging RSTS token from {Id} authenticator for Safeguard API access token, Error: " +
                                                        $"{response.StatusCode} {response.Content}", response.Content);
                 var jObject = JObject.Parse(response.Content);
                 AccessToken = jObject.GetValue("UserToken").ToString().ToSecureString();

--- a/SafeguardDotNet/Authentication/CertificateAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/CertificateAuthenticator.cs
@@ -30,6 +30,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             _clientCertificate = clientCertificate.Clone();
         }
 
+        public override string Id => "Certificate";
+
         protected override SecureString GetRstsTokenInternal()
         {
             if (_disposed)

--- a/SafeguardDotNet/Authentication/IAuthenticationMechanism.cs
+++ b/SafeguardDotNet/Authentication/IAuthenticationMechanism.cs
@@ -5,11 +5,15 @@ namespace OneIdentity.SafeguardDotNet.Authentication
 {
     internal interface IAuthenticationMechanism : IDisposable, ICloneable
     {
+        string Id { get;  }
+
         string NetworkAddress { get; }
 
         int ApiVersion { get; }
 
         bool IgnoreSsl { get; }
+
+        bool IsAnonymous { get; }
 
         bool HasAccessToken();
 

--- a/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
@@ -29,6 +29,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             _password = password.Copy();
         }
 
+        public override string Id => "Password";
+
         private void ResolveProviderToScope()
         {
             try

--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -77,13 +77,15 @@ namespace OneIdentity.SafeguardDotNet
                 throw new ArgumentException("Parameter may not be null or empty", nameof(relativeUrl));
 
             var request = new RestRequest(relativeUrl, method.ConvertToRestSharpMethod());
-            if (!_authenticationMechanism.HasAccessToken())
-                throw new SafeguardDotNetException("Access token is missing due to log out, you must refresh the access token to invoke a method");
-            if (service != Service.Notification)
+            if (!_authenticationMechanism.IsAnonymous)
+            {
+                if (!_authenticationMechanism.HasAccessToken())
+                    throw new SafeguardDotNetException("Access token is missing due to log out, you must refresh the access token to invoke a method");
                 // SecureString handling here basically negates the use of a secure string anyway, but when calling a Web API
                 // I'm not sure there is anything you can do about it.
                 request.AddHeader("Authorization",
                     $"Bearer {_authenticationMechanism.GetAccessToken().ToInsecureString()}");
+            }
             if (additionalHeaders != null && !additionalHeaders.ContainsKey("Accept"))
                 request.AddHeader("Accept", "application/json"); // Assume JSON unless specified
             if (additionalHeaders != null)

--- a/Test/Invoke-SafeguardDotNetTests.ps1
+++ b/Test/Invoke-SafeguardDotNetTests.ps1
@@ -32,7 +32,7 @@ function Invoke-DotNetRun {
     Param(
         [Parameter(Mandatory=$true, Position=0)]
         [string]$Directory,
-        [Parameter(Mandatory=$true, Position=1)]
+        [Parameter(Mandatory=$false, Position=1)]
         [string]$Password,
         [Parameter(Mandatory=$false, Position=2)]
         [string]$Command
@@ -41,7 +41,14 @@ function Invoke-DotNetRun {
     try
     {
         Push-Location $Directory
-        $local:Expression = "`"$Password`" | & dotnet.exe run -- $Command"
+        if ($Password)
+        {
+            $local:Expression = "`"$Password`" | & dotnet.exe run -- $Command"
+        }
+        else # if there is no password don't try to pass it to stdin
+        {
+            $local:Expression = "& dotnet.exe run -- $Command"
+        }
         Write-Host "Executing: $($local:Expression)"
         $local:Output = (Invoke-Expression $local:Expression)
         if ($local:Output -is [array])
@@ -145,6 +152,9 @@ Invoke-DotNetBuild $script:EventToolDir
 
 
 ### SafeguardDotNetTool Tests
+
+Write-Host -ForegroundColor Yellow "Testing whether anonymous notification Status endpoint can be reached on Safeguard ($Appliance)..."
+Invoke-DotNetRun $script:ToolDir $null "-a $Appliance -A -x -s Notification -m Get -U Status"
 
 Write-Host -ForegroundColor Yellow "Testing whether can connect to Safeguard ($Appliance) as bootstrap admin..."
 Invoke-DotNetRun $script:ToolDir "Admin123" "-a $Appliance -u Admin -x -s Core -m Get -U Me -p"

--- a/Test/Invoke-SafeguardDotNetTests.ps1
+++ b/Test/Invoke-SafeguardDotNetTests.ps1
@@ -160,16 +160,16 @@ Write-Host -ForegroundColor Yellow "Testing whether can connect to Safeguard ($A
 Invoke-DotNetRun $script:ToolDir "Admin123" "-a $Appliance -u Admin -x -s Core -m Get -U Me -p"
 
 Write-Host -ForegroundColor Yellow "Setting up a test user (SafeguardDotNetTest)..."
-if (-not (Test-ReturnsSuccess $script:ToolDir "Admin123" "-a 10.5.32.162 -u Admin -x -s Core -m Get -U `"Users?filter=UserName%20eq%20'SafeguardDotNetTest'`" -p"))
+if (-not (Test-ReturnsSuccess $script:ToolDir "Admin123" "-a $Appliance -u Admin -x -s Core -m Get -U `"Users?filter=UserName%20eq%20'SafeguardDotNetTest'`" -p"))
 {
     $local:Body = @{
         PrimaryAuthenticationProviderId = -1;
         UserName = "SafeguardDotNetTest";
         AdminRoles = @('GlobalAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
     }
-    $local:Result = (Invoke-DotNetRun $script:ToolDir "Admin123" "-a 10.5.32.162 -u Admin -x -s Core -m Post -U Users -p -b `"$(Get-StringEscapedBody $local:Body)`"")
+    $local:Result = (Invoke-DotNetRun $script:ToolDir "Admin123" "-a $Appliance -u Admin -x -s Core -m Post -U Users -p -b `"$(Get-StringEscapedBody $local:Body)`"")
     $local:Result
-    Invoke-DotNetRun $script:ToolDir "Admin123" "-a 10.5.32.162 -u Admin -x -s Core -m Put -U Users/$($local:Result.Id)/Password -p -b `"'Test123'`""
+    Invoke-DotNetRun $script:ToolDir "Admin123" "-a $Appliance -u Admin -x -s Core -m Put -U Users/$($local:Result.Id)/Password -p -b `"'Test123'`""
 }
 else
 {
@@ -177,23 +177,23 @@ else
 }
 
 Write-Host -ForegroundColor Yellow "Setting up a cert trust chain..."
-if (-not (Test-ReturnsSuccess $script:ToolDir "Admin123" "-a 10.5.32.162 -u Admin -x -s Core -m Get -U `"TrustedCertificates?filter=Thumbprint%20eq%20'$($script:RootThumbprint)'`" -p"))
+if (-not (Test-ReturnsSuccess $script:ToolDir "Admin123" "-a $Appliance -u Admin -x -s Core -m Get -U `"TrustedCertificates?filter=Thumbprint%20eq%20'$($script:RootThumbprint)'`" -p"))
 {
     $local:Body = @{
         Base64CertificateData = [string](Get-Content -Raw $script:RootCert)
     }
-    Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Post -U TrustedCertificates -p -b `"$(Get-StringEscapedBody $local:Body)`""
+    Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Post -U TrustedCertificates -p -b `"$(Get-StringEscapedBody $local:Body)`""
 }
 else
 {
     Write-Host "Root cert already exists"
 }
-if (-not (Test-ReturnsSuccess $script:ToolDir "Admin123" "-a 10.5.32.162 -u Admin -x -s Core -m Get -U `"TrustedCertificates?filter=Thumbprint%20eq%20'$($script:CaThumbprint)'`" -p"))
+if (-not (Test-ReturnsSuccess $script:ToolDir "Admin123" "-a $Appliance -u Admin -x -s Core -m Get -U `"TrustedCertificates?filter=Thumbprint%20eq%20'$($script:CaThumbprint)'`" -p"))
 {
     $local:Body = @{
         Base64CertificateData = [string](Get-Content -Raw $script:CaCert)
     }
-    Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Post -U TrustedCertificates -p -b `"$(Get-StringEscapedBody $local:Body)`""
+    Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Post -U TrustedCertificates -p -b `"$(Get-StringEscapedBody $local:Body)`""
 }
 else
 {
@@ -201,14 +201,14 @@ else
 }
 
 Write-Host -ForegroundColor Yellow "Setting up a cert user (SafeguardDotNetCert)..."
-if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"Users?filter=UserName%20eq%20'SafeguardDotNetCert'`" -p"))
+if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"Users?filter=UserName%20eq%20'SafeguardDotNetCert'`" -p"))
 {
     $local:Body = @{
         PrimaryAuthenticationProviderId = -2;
         UserName = "SafeguardDotNetCert";
         PrimaryAuthenticationIdentity = $script:UserThumbprint
     }
-    Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Post -U Users -p -b `"$(Get-StringEscapedBody $local:Body)`""
+    Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Post -U Users -p -b `"$(Get-StringEscapedBody $local:Body)`""
 }
 else
 {
@@ -228,7 +228,7 @@ Write-Host -ForegroundColor Magenta "TODO: this requires elevation to install th
 # TODO: this requires elevation to install the cert
 
 Write-Host -ForegroundColor Yellow "Setting up for asset for A2A..."
-if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"Assets?filter=Name%20eq%20'SafeguardDotNetTest'`" -p"))
+if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"Assets?filter=Name%20eq%20'SafeguardDotNetTest'`" -p"))
 {
     $local:Body = @{
         Name = "SafeguardDotNetTest";
@@ -237,22 +237,22 @@ if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a 10.5.32.162 -u Safeg
         AssetPartitionId = -1;
         NetworkAddress = "fake.address.com"
     }
-    Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Post -U Assets -p -b `"$(Get-StringEscapedBody $local:Body)`""
+    Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Post -U Assets -p -b `"$(Get-StringEscapedBody $local:Body)`""
 }
 else
 {
     Write-Host "'SafeguardDotNetTest' asset already exists"
 }
-$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"Assets?filter=Name%20eq%20'SafeguardDotNetTest'`" -p")
-if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"Assets/$($local:Result.Id)/Accounts?filter=Name%20eq%20'SafeguardDotNetTest'`" -p"))
+$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"Assets?filter=Name%20eq%20'SafeguardDotNetTest'`" -p")
+if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"Assets/$($local:Result.Id)/Accounts?filter=Name%20eq%20'SafeguardDotNetTest'`" -p"))
 {
     $local:Body = @{
         Name = "SafeguardDotNetTest";
         AssetId = $local:Result.Id
     }
-    $local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Post -U `"AssetAccounts`" -p -b `"$(Get-StringEscapedBody $local:Body)`"")
+    $local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Post -U `"AssetAccounts`" -p -b `"$(Get-StringEscapedBody $local:Body)`"")
     $local:Result
-    Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Put -U `"AssetAccounts/$($local:Result.Id)/Password`" -p -b `"'Test123'`""
+    Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Put -U `"AssetAccounts/$($local:Result.Id)/Password`" -p -b `"'Test123'`""
 }
 else
 {
@@ -260,25 +260,25 @@ else
 }
 
 Write-Host -ForegroundColor Yellow "Setting up for A2A credential retrieval..."
-if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations?filter=AppName%20eq%20'SafeguardDotNetTest'`" -p"))
+if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations?filter=AppName%20eq%20'SafeguardDotNetTest'`" -p"))
 {
-    $local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"Users?filter=UserName%20eq%20'SafeguardDotNetCert'`" -p")
+    $local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"Users?filter=UserName%20eq%20'SafeguardDotNetCert'`" -p")
     $local:Body = @{
         AppName = "SafeguardDotNetTest";
         Description = "test a2a registration for SafeguardDotNet test script";
         CertificateUserId = $local:Result.Id
     }
-    Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Post -U A2ARegistrations -p -b `"$(Get-StringEscapedBody $local:Body)`""
+    Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Post -U A2ARegistrations -p -b `"$(Get-StringEscapedBody $local:Body)`""
 }
 else
 {
     Write-Host "'SafeguardDotNetTest' A2A registration already exists"
 }
-$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations?filter=AppName%20eq%20'SafeguardDotNetTest'`" -p")
-if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations/$($local:Result.Id)/RetrievableAccounts?filter=AccountName%20eq%20'SafeguardDotNetTest'`" -p"))
+$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations?filter=AppName%20eq%20'SafeguardDotNetTest'`" -p")
+if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations/$($local:Result.Id)/RetrievableAccounts?filter=AccountName%20eq%20'SafeguardDotNetTest'`" -p"))
 {
     $local:A2aId = $local:Result.Id
-    $local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"AssetAccounts?filter=Name%20eq%20'SafeguardDotNetTest'`" -p")
+    $local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"AssetAccounts?filter=Name%20eq%20'SafeguardDotNetTest'`" -p")
     if (-not $local:Result)
     {
         throw "Couldn't find asset account SafeguardDotNetTest to create A2A account retrieval"
@@ -287,24 +287,25 @@ if (-not (Test-ReturnsSuccess $script:ToolDir "Test123" "-a 10.5.32.162 -u Safeg
         SystemId = $local:Result.AssetId;
         AccountId = $local:Result.Id
     }
-    Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Post -U `"A2ARegistrations/$($local:A2aId)/RetrievableAccounts`" -p -b `"$(Get-StringEscapedBody $local:Body)`""
+    Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Post -U `"A2ARegistrations/$($local:A2aId)/RetrievableAccounts`" -p -b `"$(Get-StringEscapedBody $local:Body)`""
 }
 else
 {
     Write-Host "'SafeguardDotNetTest' A2A registration account retrieval already exists"
 }
+Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Appliance -m Post -U `"A2AService/Enable`" -p"
 
 
 ### SafeguardDotNetA2aTool Tests
 
-$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations?filter=AppName%20eq%20'SafeguardDotNetTest'`" -p")
-$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a 10.5.32.162 -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations/$($local:Result.Id)/RetrievableAccounts?filter=AccountName%20eq%20'SafeguardDotNetTest'`" -p")
+$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations?filter=AppName%20eq%20'SafeguardDotNetTest'`" -p")
+$local:Result = (Invoke-DotNetRun $script:ToolDir "Test123" "-a $Appliance -u SafeguardDotNetTest -x -s Core -m Get -U `"A2ARegistrations/$($local:Result.Id)/RetrievableAccounts?filter=AccountName%20eq%20'SafeguardDotNetTest'`" -p")
 $script:A2aCrApiKey = $local:Result.ApiKey
 
 Write-Host -ForegroundColor Yellow "Calling A2A credential retrieval with Pfx file..."
-Invoke-DotNetRun $script:A2aToolDir "a" "-a 10.5.32.162 -x -c $($script:UserPfx) -A `"$($script:A2aCrApiKey)`" -p"
+Invoke-DotNetRun $script:A2aToolDir "a" "-a $Appliance -x -c $($script:UserPfx) -A `"$($script:A2aCrApiKey)`" -p"
 
 Write-Host -ForegroundColor Yellow "Calling A2A credential retrieval from User Certificate Store..."
 Import-PfxCertificate $script:UserPfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -AsPlainText 'a' -Force)
-Invoke-DotNetRun $script:A2aToolDir "a" "-a 10.5.32.162 -x -t $($script:UserThumbprint) -A `"$($script:A2aCrApiKey)`" -p"
+Invoke-DotNetRun $script:A2aToolDir "a" "-a $Appliance -x -t $($script:UserThumbprint) -A `"$($script:A2aCrApiKey)`" -p"
 Remove-Item "Cert:\CurrentUser\My\$($script:UserThumbprint)"

--- a/Test/SafeguardDotNetTool/Program.cs
+++ b/Test/SafeguardDotNetTool/Program.cs
@@ -71,9 +71,13 @@ namespace SafeguardDotNetTool
                 {
                     connection = Safeguard.Connect(opts.Appliance, opts.Thumbprint, opts.ApiVersion, opts.Insecure);
                 }
+                else if (opts.Anonymous)
+                {
+                    connection = Safeguard.Connect(opts.Appliance, opts.ApiVersion, opts.Insecure);
+                }
                 else
                 {
-                    throw new Exception("Must specify Username, CertificateFile, or Thumbprint");
+                    throw new Exception("Must specify Anonymous, Username, CertificateFile, or Thumbprint");
                 }
 
                 Log.Debug($"Access Token Lifetime Remaining: {connection.GetAccessTokenLifetimeRemaining()}");

--- a/Test/SafeguardDotNetTool/ToolOptions.cs
+++ b/Test/SafeguardDotNetTool/ToolOptions.cs
@@ -17,6 +17,10 @@ namespace SafeguardDotNetTool
             HelpText = "Read any required password from console stdin")]
         public bool ReadPassword { get; set; }
 
+        [Option('A', "Anonymous", Required = true, SetName = "AnonymousSet",
+            HelpText =  "Do not authenticate, call API anonymously")]
+        public bool Anonymous { get; set; }
+
         [Option('V', "Verbose", Required = false, Default = false,
             HelpText = "Display verbose debug output")]
         public bool Verbose { get; set; }


### PR DESCRIPTION
Fix for #46 

I had stupidly broken the test script by hard-coding some IPs
Expanded the interface for authentication mechanisms and used that to check whether it was anonymous so that the connection class could determine whether or not to insert a token.