### PR TITLE
Add custom SSL certificate validation

### DIFF
--- a/SafeguardDotNet/Authentication/AccessTokenAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/AccessTokenAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Security;
 using System.Security;
 
 namespace OneIdentity.SafeguardDotNet.Authentication
@@ -8,7 +9,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         private bool _disposed;
 
         public AccessTokenAuthenticator(string networkAddress, SecureString accessToken,
-            int apiVersion, bool ignoreSsl) : base(networkAddress, apiVersion, ignoreSsl)
+            int apiVersion, bool ignoreSsl, RemoteCertificateValidationCallback validationCallback) : base(networkAddress, apiVersion, ignoreSsl, validationCallback)
         {
             if (accessToken == null)
                 throw new ArgumentException("Parameter may not be null", nameof(accessToken));

--- a/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Security;
 using System.Security;
 using RestSharp;
 
@@ -8,13 +9,15 @@ namespace OneIdentity.SafeguardDotNet.Authentication
     {
         private bool _disposed;
 
-        public AnonymousAuthenticator(string networkAddress, int apiVersion, bool ignoreSsl) :
-            base(networkAddress, apiVersion, ignoreSsl)
+        public AnonymousAuthenticator(string networkAddress, int apiVersion, bool ignoreSsl, RemoteCertificateValidationCallback validationCallback) :
+            base(networkAddress, apiVersion, ignoreSsl, validationCallback)
         {
             var notificationUrl = $"https://{NetworkAddress}/service/notification/v{ApiVersion}";
             var notificationClient = new RestClient(notificationUrl);
             if (ignoreSsl)
                 notificationClient.RemoteCertificateValidationCallback += (sender, certificate, chain, errors) => true;
+            else if (validationCallback != null)
+                notificationClient.RemoteCertificateValidationCallback += validationCallback;
             var request = new RestRequest("Status", RestSharp.Method.GET)
                 .AddHeader("Accept", "application/json")
                 .AddHeader("Content-type", "application/json");

--- a/SafeguardDotNet/Authentication/AuthenticatorBase.cs
+++ b/SafeguardDotNet/Authentication/AuthenticatorBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net.Security;
 using System.Security;
 using Newtonsoft.Json.Linq;
 using RestSharp;
@@ -18,7 +19,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         protected RestClient RstsClient;
         protected RestClient CoreClient;
 
-        protected AuthenticatorBase(string networkAddress, int apiVersion, bool ignoreSsl)
+        protected AuthenticatorBase(string networkAddress, int apiVersion, bool ignoreSsl, RemoteCertificateValidationCallback validationCallback)
         {
             NetworkAddress = networkAddress;
             ApiVersion = apiVersion;
@@ -32,8 +33,16 @@ namespace OneIdentity.SafeguardDotNet.Authentication
             if (ignoreSsl)
             {
                 IgnoreSsl = true;
+                ValidationCallback = null;
                 RstsClient.RemoteCertificateValidationCallback += (sender, certificate, chain, errors) => true;
                 CoreClient.RemoteCertificateValidationCallback += (sender, certificate, chain, errors) => true;
+            } 
+            else if (validationCallback != null)
+            {
+                IgnoreSsl = false;
+                ValidationCallback = validationCallback;
+                RstsClient.RemoteCertificateValidationCallback += validationCallback;
+                CoreClient.RemoteCertificateValidationCallback += validationCallback;
             }
         }
 
@@ -44,6 +53,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         public int ApiVersion { get; }
 
         public bool IgnoreSsl { get; }
+
+        public RemoteCertificateValidationCallback ValidationCallback { get; }
 
         public virtual bool IsAnonymous => false;
 

--- a/SafeguardDotNet/Authentication/CertificateAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/CertificateAuthenticator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Security;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Newtonsoft.Json.Linq;
@@ -14,25 +15,25 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         private readonly CertificateContext _clientCertificate;
 
         public CertificateAuthenticator(string networkAddress, string certificateThumbprint, int apiVersion,
-            bool ignoreSsl) : base(networkAddress, apiVersion, ignoreSsl)
+            bool ignoreSsl, RemoteCertificateValidationCallback validationCallback) : base(networkAddress, apiVersion, ignoreSsl, validationCallback)
         {
             _clientCertificate = new CertificateContext(certificateThumbprint);
         }
 
         public CertificateAuthenticator(string networkAddress, string certificatePath, SecureString certificatePassword,
-            int apiVersion, bool ignoreSsl) : base(networkAddress, apiVersion, ignoreSsl)
+            int apiVersion, bool ignoreSsl, RemoteCertificateValidationCallback validationCallback) : base(networkAddress, apiVersion, ignoreSsl, validationCallback)
         {
             _clientCertificate = new CertificateContext(certificatePath, certificatePassword);
         }
 
-        public CertificateAuthenticator(string networkAddress, IEnumerable<byte> certificateData,
-            SecureString certificatePassword, int apiVersion, bool ignoreSsl) : base(networkAddress, apiVersion, ignoreSsl)
+        public CertificateAuthenticator(string networkAddress, IEnumerable<byte> certificateData, SecureString certificatePassword, 
+            int apiVersion, bool ignoreSsl, RemoteCertificateValidationCallback validationCallback) : base(networkAddress, apiVersion, ignoreSsl, validationCallback)
         {
             _clientCertificate = new CertificateContext(certificateData, certificatePassword);
         }
 
         private CertificateAuthenticator(string networkAddress, CertificateContext clientCertificate, int apiVersion,
-            bool ignoreSsl) : base(networkAddress, apiVersion, ignoreSsl)
+            bool ignoreSsl, RemoteCertificateValidationCallback validationCallback) : base(networkAddress, apiVersion, ignoreSsl, validationCallback)
         {
             _clientCertificate = clientCertificate.Clone();
         }
@@ -67,7 +68,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
 
         public override object Clone()
         {
-            var auth = new CertificateAuthenticator(NetworkAddress, _clientCertificate, ApiVersion, IgnoreSsl)
+            var auth = new CertificateAuthenticator(NetworkAddress, _clientCertificate, ApiVersion, IgnoreSsl, ValidationCallback)
             {
                 AccessToken = AccessToken?.Copy()
             };

--- a/SafeguardDotNet/Authentication/IAuthenticationMechanism.cs
+++ b/SafeguardDotNet/Authentication/IAuthenticationMechanism.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Security;
 using System.Security;
 
 namespace OneIdentity.SafeguardDotNet.Authentication
@@ -12,6 +13,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         int ApiVersion { get; }
 
         bool IgnoreSsl { get; }
+
+        RemoteCertificateValidationCallback ValidationCallback { get; }
 
         bool IsAnonymous { get; }
 

--- a/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using System.Net.Security;
 using System.Security;
 using Newtonsoft.Json.Linq;
 using RestSharp;
@@ -17,8 +18,8 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         private readonly string _username;
         private readonly SecureString _password;
 
-        public PasswordAuthenticator(string networkAddress, string provider, string username,
-            SecureString password, int apiVersion, bool ignoreSsl) : base(networkAddress, apiVersion, ignoreSsl)
+        public PasswordAuthenticator(string networkAddress, string provider, string username, SecureString password, int apiVersion, 
+            bool ignoreSsl, RemoteCertificateValidationCallback validationCallback) : base(networkAddress, apiVersion, ignoreSsl, validationCallback)
         {
             _provider = provider;
             if (string.IsNullOrEmpty(_provider))
@@ -126,7 +127,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         public override object Clone()
         {
             var auth =
-                new PasswordAuthenticator(NetworkAddress, _provider, _username, _password, ApiVersion, IgnoreSsl)
+                new PasswordAuthenticator(NetworkAddress, _provider, _username, _password, ApiVersion, IgnoreSsl, ValidationCallback)
                 {
                     AccessToken = AccessToken?.Copy()
                 };

--- a/SafeguardDotNet/CustomDelegateSslValidationHttpClient.cs
+++ b/SafeguardDotNet/CustomDelegateSslValidationHttpClient.cs
@@ -30,7 +30,7 @@ namespace OneIdentity.SafeguardDotNet
             return messageHandler;
         }
 
-        bool ValidationCallback(HttpRequestMessage sender, X509Certificate2 certificate, X509Chain chain,
+        private bool ValidationCallback(HttpRequestMessage sender, X509Certificate2 certificate, X509Chain chain,
             SslPolicyErrors sslPolicyErrors)
         {
             return _validationCallback(sender, certificate, chain, sslPolicyErrors);

--- a/SafeguardDotNet/CustomDelegateSslValidationHttpClient.cs
+++ b/SafeguardDotNet/CustomDelegateSslValidationHttpClient.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNet.SignalR.Client.Http;
+
+namespace OneIdentity.SafeguardDotNet
+{
+    internal class CustomDelegateSslValidationHttpClient : DefaultHttpClient
+    {
+        private readonly RemoteCertificateValidationCallback _validationCallback;
+
+        public CustomDelegateSslValidationHttpClient(RemoteCertificateValidationCallback validationCallback)
+        {
+            _validationCallback = validationCallback;
+        }
+
+        protected override HttpMessageHandler CreateHandler()
+        {
+            var messageHandler = base.CreateHandler();
+            if (!(messageHandler is HttpClientHandler))
+            {
+                throw new Exception("Unable to create the customer HttpClientHandler");
+            }
+            if (_validationCallback == null)
+            {
+                throw new Exception("Unable to get HttpClientHandler to ignore certificate errors");
+            }
+            ((HttpClientHandler)messageHandler).ServerCertificateCustomValidationCallback = ValidationCallback;
+            return messageHandler;
+        }
+
+        bool ValidationCallback(HttpRequestMessage sender, X509Certificate2 certificate, X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            return _validationCallback(sender, certificate, chain, sslPolicyErrors);
+        }
+    }
+}

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net.Security;
 using System.Security;
 using OneIdentity.SafeguardDotNet.A2A;
 using OneIdentity.SafeguardDotNet.Authentication;
@@ -30,7 +31,21 @@ namespace OneIdentity.SafeguardDotNet
         {
             // Don't try to refresh access token on the anonymous connect method because it cannot be refreshed
             // So, don't use GetConnection() function above
-            return new SafeguardConnection(new AnonymousAuthenticator(networkAddress, apiVersion, ignoreSsl));
+            return new SafeguardConnection(new AnonymousAuthenticator(networkAddress, apiVersion, ignoreSsl, null));
+        }
+
+        /// <summary>
+        /// Connect to Safeguard API anonymously.
+        /// </summary>
+        /// <returns>The connect.</returns>
+        /// <param name="networkAddress">Network address.</param>
+        /// <param name="validationCallback">Certificate validation callback delegate.</param>
+        /// <param name="apiVersion">API version.</param>
+        public static ISafeguardConnection Connect(string networkAddress, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+        {
+            // Don't try to refresh access token on the anonymous connect method because it cannot be refreshed
+            // So, don't use GetConnection() function above
+            return new SafeguardConnection(new AnonymousAuthenticator(networkAddress, apiVersion, false, validationCallback));
         }
 
         /// <summary>
@@ -46,7 +61,23 @@ namespace OneIdentity.SafeguardDotNet
         {
             // Don't try to refresh access token on the access token connect method because it cannot be refreshed
             // So, don't use GetConnection() function above
-            return new SafeguardConnection(new AccessTokenAuthenticator(networkAddress, accessToken, apiVersion, ignoreSsl));
+            return new SafeguardConnection(new AccessTokenAuthenticator(networkAddress, accessToken, apiVersion, ignoreSsl, null));
+        }
+
+        /// <summary>
+        /// Connect to Safeguard API using an API access token.
+        /// </summary>
+        /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+        /// <param name="accessToken">Existing API access token.</param>
+        /// <param name="validationCallback">Certificate validation callback delegate.</param>
+        /// <param name="apiVersion">Target API version to use.</param>
+        /// <returns>Reusable Safeguard API connection.</returns>
+        public static ISafeguardConnection Connect(string networkAddress, SecureString accessToken,
+            RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+        {
+            // Don't try to refresh access token on the access token connect method because it cannot be refreshed
+            // So, don't use GetConnection() function above
+            return new SafeguardConnection(new AccessTokenAuthenticator(networkAddress, accessToken, apiVersion, false, validationCallback));
         }
 
         /// <summary>
@@ -63,7 +94,24 @@ namespace OneIdentity.SafeguardDotNet
             SecureString password, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
         {
             return GetConnection(new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion,
-                ignoreSsl));
+                ignoreSsl, null));
+        }
+
+        /// <summary>
+        /// Connect to Safeguard API using a user name and password.
+        /// </summary>
+        /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+        /// <param name="provider">Safeguard authentication provider name (e.g. local).</param>
+        /// <param name="username">User name to use for authentication.</param>
+        /// <param name="password">User password to use for authentication.</param>
+        /// <param name="validationCallback">Certificate validation callback delegate.</param>
+        /// <param name="apiVersion">Target API version to use.</param>
+        /// <returns>Reusable Safeguard API connection.</returns>
+        public static ISafeguardConnection Connect(string networkAddress, string provider, string username,
+            SecureString password, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+        {
+            return GetConnection(new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion,
+                false, validationCallback));
         }
 
         /// <summary>
@@ -79,7 +127,23 @@ namespace OneIdentity.SafeguardDotNet
             int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
         {
             return GetConnection(new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion,
-                ignoreSsl));
+                ignoreSsl, null));
+        }
+
+        /// <summary>
+        /// Connect to Safeguard API using a client certificate from the certificate store.  Use PowerShell to list
+        /// certificates with SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
+        /// </summary>
+        /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+        /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+        /// <param name="validationCallback">Certificate validation callback delegate.</param>
+        /// <param name="apiVersion">Target API version to use.</param>
+        /// <returns>Reusable Safeguard API connection.</returns>
+        public static ISafeguardConnection Connect(string networkAddress, string certificateThumbprint,
+            RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+        {
+            return GetConnection(new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion,
+                false, validationCallback));
         }
 
         /// <summary>
@@ -95,7 +159,23 @@ namespace OneIdentity.SafeguardDotNet
             SecureString certificatePassword, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
         {
             return GetConnection(new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword,
-                apiVersion, ignoreSsl));
+                apiVersion, ignoreSsl, null));
+        }
+
+        /// <summary>
+        /// Connect to Safeguard API using a client certificate stored in a file.
+        /// </summary>
+        /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+        /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+        /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+        /// <param name="validationCallback">Certificate validation callback delegate.</param>
+        /// <param name="apiVersion">Target API version to use.</param>
+        /// <returns>Reusable Safeguard API connection.</returns>
+        public static ISafeguardConnection Connect(string networkAddress, string certificatePath,
+            SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+        {
+            return GetConnection(new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword,
+                apiVersion, false, validationCallback));
         }
 
         /// <summary>
@@ -111,7 +191,23 @@ namespace OneIdentity.SafeguardDotNet
             SecureString certificatePassword, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
         {
             return GetConnection(new CertificateAuthenticator(networkAddress, certificateData, certificatePassword,
-                apiVersion, ignoreSsl));
+                apiVersion, ignoreSsl, null));
+        }
+
+        /// <summary>
+        /// Connect to Safeguard API using a client certificate stored in a memory.
+        /// </summary>
+        /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+        /// <param name="certificateData">Bytes containing a PFX (or PKCS12) formatted certificate and private key.</param>
+        /// <param name="certificatePassword">Password to decrypt the certificate data.</param>
+        /// <param name="validationCallback">Certificate validation callback delegate.</param>
+        /// <param name="apiVersion">Target API version to use.</param>
+        /// <returns>Reusable Safeguard API connection.</returns>
+        public static ISafeguardConnection Connect(string networkAddress, IEnumerable<byte> certificateData,
+            SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+        {
+            return GetConnection(new CertificateAuthenticator(networkAddress, certificateData, certificatePassword,
+                apiVersion, false, validationCallback));
         }
 
         /// <summary>
@@ -135,7 +231,24 @@ namespace OneIdentity.SafeguardDotNet
                 string username, SecureString password, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
             {
                 return new PersistentSafeguardEventListener(GetConnection(
-                    new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion, ignoreSsl)));
+                    new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion, ignoreSsl, null)));
+            }
+
+            /// <summary>
+            /// Get a persistent event listener using a username and password credentia for authentication.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="provider">Safeguard authentication provider name (e.g. local).</param>
+            /// <param name="username">User name to use for authentication.</param>
+            /// <param name="password">User password to use for authentication.</param>
+            /// <param name="validationCallback">Certificate validation callback delegate.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
+            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress, string provider,
+                string username, SecureString password, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+            {
+                return new PersistentSafeguardEventListener(GetConnection(
+                    new PasswordAuthenticator(networkAddress, provider, username, password, apiVersion, false, validationCallback)));
             }
 
             /// <summary>
@@ -151,7 +264,23 @@ namespace OneIdentity.SafeguardDotNet
                 string certificateThumbprint, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
             {
                 return new PersistentSafeguardEventListener(GetConnection(
-                    new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion, ignoreSsl)));
+                    new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion, ignoreSsl, null)));
+            }
+
+            /// <summary>
+            /// Get a persistent event listener using a client certificate from the certificate store for authentication.
+            /// Use PowerShell to list certificates with SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+            /// <param name="validationCallback">Certificate validation callback delegate.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
+            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
+                string certificateThumbprint, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+            {
+                return new PersistentSafeguardEventListener(GetConnection(
+                    new CertificateAuthenticator(networkAddress, certificateThumbprint, apiVersion, false, validationCallback)));
             }
 
             /// <summary>
@@ -168,7 +297,23 @@ namespace OneIdentity.SafeguardDotNet
                 bool ignoreSsl = false)
             {
                 return new PersistentSafeguardEventListener(GetConnection(new CertificateAuthenticator(networkAddress,
-                    certificateData, certificatePassword, apiVersion, ignoreSsl)));
+                    certificateData, certificatePassword, apiVersion, ignoreSsl, null)));
+            }
+
+            /// <summary>
+            /// Get a persistent event listener using a client certificate stored in memory.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificateData">Bytes containing a PFX (or PKCS12) formatted certificate and private key.</param>
+            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+            /// <param name="validationCallback">Certificate validation callback delegate.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
+            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
+                IEnumerable<byte> certificateData, SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+            {
+                return new PersistentSafeguardEventListener(GetConnection(new CertificateAuthenticator(networkAddress,
+                    certificateData, certificatePassword, apiVersion, false, validationCallback)));
             }
 
             /// <summary>
@@ -185,7 +330,23 @@ namespace OneIdentity.SafeguardDotNet
                 bool ignoreSsl = false)
             {
                 return new PersistentSafeguardEventListener(GetConnection(new CertificateAuthenticator(networkAddress,
-                    certificatePath, certificatePassword, apiVersion, ignoreSsl)));
+                    certificatePath, certificatePassword, apiVersion, ignoreSsl, null)));
+            }
+
+            /// <summary>
+            /// Get a persistent event listener using a client certificate stored in a file.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+            /// <param name="validationCallback">Certificate validation callback delegate.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <returns>New persistent Safeguard event listener.</returns>
+            public static ISafeguardEventListener GetPersistentEventListener(string networkAddress,
+                string certificatePath, SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+            {
+                return new PersistentSafeguardEventListener(GetConnection(new CertificateAuthenticator(networkAddress,
+                    certificatePath, certificatePassword, apiVersion, false, validationCallback)));
             }
         }
 
@@ -206,7 +367,22 @@ namespace OneIdentity.SafeguardDotNet
             public static ISafeguardA2AContext GetContext(string networkAddress, string certificateThumbprint,
                 int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
             {
-                return new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl);
+                return new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl, null);
+            }
+
+            /// <summary>
+            /// Establish a Safeguard A2A context using a client certificate from the certificate store.  Use PowerShell to
+            /// list certificates with SHA-1 thumbprint.  PS> gci Cert:\CurrentUser\My
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+            /// <param name="validationCallback">Certificate validation callback delegate.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <returns>Reusable Safeguard A2A context.</returns>
+            public static ISafeguardA2AContext GetContext(string networkAddress, string certificateThumbprint, 
+                RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+            {
+                return new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, false, validationCallback);
             }
 
             /// <summary>
@@ -221,7 +397,22 @@ namespace OneIdentity.SafeguardDotNet
             public static ISafeguardA2AContext GetContext(string networkAddress, string certificatePath,
                 SecureString certificatePassword, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
             {
-                return new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion, ignoreSsl);
+                return new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion, ignoreSsl, null);
+            }
+
+            /// <summary>
+            /// Establish a Safeguard A2A context using a client certificate stored in a file.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+            /// <param name="validationCallback">Certificate validation callback delegate.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <returns>Reusable Safeguard A2A context.</returns>
+            public static ISafeguardA2AContext GetContext(string networkAddress, string certificatePath,
+                SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+            {
+                return new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion, false, validationCallback);
             }
 
             /// <summary>
@@ -236,7 +427,22 @@ namespace OneIdentity.SafeguardDotNet
             public static ISafeguardA2AContext GetContext(string networkAddress, IEnumerable<byte> certificateData,
                 SecureString certificatePassword, int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
             {
-                return new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, apiVersion, ignoreSsl);
+                return new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, apiVersion, ignoreSsl, null);
+            }
+
+            /// <summary>
+            /// Establish a Safeguard A2A context using a client certificate stored in memory.
+            /// </summary>
+            /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+            /// <param name="certificateData">Bytes containing a PFX (or PKCS12) formatted certificate and private key.</param>
+            /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+            /// <param name="validationCallback">Certificate validation callback delegate.</param>
+            /// <param name="apiVersion">Target API version to use.</param>
+            /// <returns>Reusable Safeguard A2A context.</returns>
+            public static ISafeguardA2AContext GetContext(string networkAddress, IEnumerable<byte> certificateData,
+                SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+            {
+                return new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, apiVersion, false, validationCallback);
             }
 
             /// <summary>
@@ -264,8 +470,29 @@ namespace OneIdentity.SafeguardDotNet
                     int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
                 {
                     return new PersistentSafeguardA2AEventListener(
-                        new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl), apiKey,
+                        new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl, null), apiKey,
                             handler);
+                }
+
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A. Uses a client certificate
+                /// from the certificate store.
+                /// </summary>
+                /// <param name="apiKey">API key corresponding to the configured account to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+                /// <param name="validationCallback">Certificate validation callback delegate.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(SecureString apiKey,
+                    SafeguardEventHandler handler, string networkAddress, string certificateThumbprint,
+                    RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, false, validationCallback), apiKey,
+                        handler);
                 }
 
                 /// <summary>
@@ -285,13 +512,34 @@ namespace OneIdentity.SafeguardDotNet
                     int apiVersion = DefaultApiVersion, bool ignoreSsl = false)
                 {
                     return new PersistentSafeguardA2AEventListener(
-                        new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl), apiKeys, 
+                        new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, ignoreSsl, null), apiKeys, 
                             handler);
                 }
 
                 /// <summary>
                 /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
                 /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A. Uses a client certificate
+                /// from the certificate store.
+                /// </summary>
+                /// <param name="apiKeys">A list of API keys corresponding to the configured accounts to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificateThumbprint">SHA-1 hash identifying a client certificate in personal (My) store.</param>
+                /// <param name="validationCallback">Certificate validation callback delegate.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(IEnumerable<SecureString> apiKeys,
+                    SafeguardEventHandler handler, string networkAddress, string certificateThumbprint,
+                    RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateThumbprint, apiVersion, false, validationCallback), apiKeys, 
+                        handler);
+                }
+
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A. Uses a client certificate
                 /// stored in a file.
                 /// </summary>
                 /// <param name="apiKey">API key corresponding to the configured account to listen for.</param>
@@ -308,7 +556,29 @@ namespace OneIdentity.SafeguardDotNet
                 {
                     return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion,
-                            ignoreSsl), apiKey, handler);
+                            ignoreSsl, null), apiKey, handler);
+                }
+
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A. Uses a client certificate
+                /// stored in a file.
+                /// </summary>
+                /// <param name="apiKey">API key corresponding to the configured account to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+                /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+                /// <param name="validationCallback">Certificate validation callback delegate.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(SecureString apiKey,
+                    SafeguardEventHandler handler, string networkAddress, string certificatePath,
+                    SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion,
+                            false, validationCallback), apiKey, handler);
                 }
 
                 /// <summary>
@@ -330,7 +600,29 @@ namespace OneIdentity.SafeguardDotNet
                 {
                     return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion,
-                            ignoreSsl), apiKeys, handler);
+                            ignoreSsl, null), apiKeys, handler);
+                }
+
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A. Uses a client certificate
+                /// stored in a file.
+                /// </summary>
+                /// <param name="apiKeys">A list of API keys corresponding to the configured accounts to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificatePath">Path to PFX (or PKCS12) certificate file also containing private key.</param>
+                /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+                /// <param name="validationCallback">Certificate validation callback delegate.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(IEnumerable<SecureString> apiKeys,
+                    SafeguardEventHandler handler, string networkAddress, string certificatePath,
+                    SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, apiVersion,
+                            false, validationCallback), apiKeys, handler);
                 }
 
                 /// <summary>
@@ -352,7 +644,29 @@ namespace OneIdentity.SafeguardDotNet
                 {
                     return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, apiVersion,
-                            ignoreSsl), apiKey, handler);
+                            ignoreSsl, null), apiKey, handler);
+                }
+
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A. Uses a client certificate
+                /// stored in memory.
+                /// </summary>
+                /// <param name="apiKey">API key corresponding to the configured account to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificateData">Bytes containing a PFX (or PKCS12) formatted certificate and private key.</param>
+                /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+                /// <param name="validationCallback">Certificate validation callback delegate.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(SecureString apiKey,
+                    SafeguardEventHandler handler, string networkAddress, IEnumerable<byte> certificateData,
+                    SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, apiVersion,
+                            false, validationCallback), apiKey, handler);
                 }
 
                 /// <summary>
@@ -374,7 +688,29 @@ namespace OneIdentity.SafeguardDotNet
                 {
                     return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, apiVersion,
-                            ignoreSsl), apiKeys, handler);
+                            ignoreSsl, null), apiKeys, handler);
+                }
+
+                /// <summary>
+                /// Get a persistent A2A event listener for Gets an A2A event listener. The handler passed in will be registered
+                /// for the AssetAccountPasswordUpdated event, which is the only one supported in A2A. Uses a client certificate
+                /// stored in memory.
+                /// </summary>
+                /// <param name="apiKeys">A list of API keys corresponding to the configured accounts to listen for.</param>
+                /// <param name="handler">A delegate to call any time the AssetAccountPasswordUpdate event occurs.</param>
+                /// <param name="networkAddress">Network address of Safeguard appliance.</param>
+                /// <param name="certificateData">Bytes containing a PFX (or PKCS12) formatted certificate and private key.</param>
+                /// <param name="certificatePassword">Password to decrypt the certificate file.</param>
+                /// <param name="validationCallback">Certificate validation callback delegate.</param>
+                /// <param name="apiVersion">Target API version to use.</param>
+                /// <returns>New persistent A2A event listener.</returns>
+                public static ISafeguardEventListener GetPersistentA2AEventListener(IEnumerable<SecureString> apiKeys,
+                    SafeguardEventHandler handler, string networkAddress, IEnumerable<byte> certificateData,
+                    SecureString certificatePassword, RemoteCertificateValidationCallback validationCallback, int apiVersion = DefaultApiVersion)
+                {
+                    return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, apiVersion,
+                            false, validationCallback), apiKeys, handler);
                 }
             }
         }

--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -37,6 +37,12 @@ namespace OneIdentity.SafeguardDotNet
                 _applianceClient.RemoteCertificateValidationCallback += (sender, certificate, chain, errors) => true;
                 _notificationClient.RemoteCertificateValidationCallback += (sender, certificate, chain, errors) => true;
             }
+            else if (authenticationMechanism.ValidationCallback != null)
+            {
+                _coreClient.RemoteCertificateValidationCallback += authenticationMechanism.ValidationCallback;
+                _applianceClient.RemoteCertificateValidationCallback += authenticationMechanism.ValidationCallback;
+                _notificationClient.RemoteCertificateValidationCallback += authenticationMechanism.ValidationCallback;
+            }
         }
 
         public int GetAccessTokenLifetimeRemaining()
@@ -157,7 +163,7 @@ namespace OneIdentity.SafeguardDotNet
                 throw new ObjectDisposedException("SafeguardConnection");
             var eventListener = new SafeguardEventListener(
                 $"https://{_authenticationMechanism.NetworkAddress}/service/event",
-                _authenticationMechanism.GetAccessToken(), _authenticationMechanism.IgnoreSsl);
+                _authenticationMechanism.GetAccessToken(), _authenticationMechanism.IgnoreSsl, _authenticationMechanism.ValidationCallback);
             Log.Debug("Event listener successfully created for Safeguard connection.");
             return eventListener;
         }


### PR DESCRIPTION
Add a way for the caller to provide SafeguardDotNet with a certificate validation callback delegate.  This allows the caller to validate the SSL certificate without having to depend on the windows certificate validation.