### PR TITLE
Support for SSH private key in A2A

### DIFF
--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -31,7 +31,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
         /// <param name="apiKey">API key corresponding to the configured account.</param>
         /// <param name="keyFormat">Format to use when returning private key.</param>
         /// <returns>The SSH private key.</returns>
-        SecureString RetrievePrivateKey(SecureString apiKey, KeyFormat keyFormat);
+        SecureString RetrievePrivateKey(SecureString apiKey, KeyFormat keyFormat = KeyFormat.OpenSsh);
 
         /// <summary>
         /// Gets an A2A event listener. The handler passed in will be registered for the AssetAccountPasswordUpdated

--- a/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/ISafeguardA2AContext.cs
@@ -26,6 +26,14 @@ namespace OneIdentity.SafeguardDotNet.A2A
         SecureString RetrievePassword(SecureString apiKey);
 
         /// <summary>
+        /// Retrieves an SSH private key using Safeguard A2A.
+        /// </summary>
+        /// <param name="apiKey">API key corresponding to the configured account.</param>
+        /// <param name="keyFormat">Format to use when returning private key.</param>
+        /// <returns>The SSH private key.</returns>
+        SecureString RetrievePrivateKey(SecureString apiKey, KeyFormat keyFormat);
+
+        /// <summary>
         /// Gets an A2A event listener. The handler passed in will be registered for the AssetAccountPasswordUpdated
         /// event, which is the only one supported in A2A. You just have to call Start(). The event listener returned
         /// by this method WILL NOT automatically recover from a SignalR timeout which occurs when there is a 30+

--- a/SafeguardDotNet/A2A/SafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/SafeguardA2AContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Net.Security;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -190,6 +189,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
             var eventListener = new SafeguardEventListener($"https://{_networkAddress}/service/a2a", _clientCertificate,
                 apiKey, _ignoreSsl, _validationCallback);
             eventListener.RegisterEventHandler("AssetAccountPasswordUpdated", handler);
+            eventListener.RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
             Log.Debug("Event listener successfully created for Safeguard A2A context.");
             return eventListener;
         }
@@ -204,6 +204,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
             var eventListener = new SafeguardEventListener($"https://{_networkAddress}/service/a2a", _clientCertificate,
                 apiKeys, _ignoreSsl, _validationCallback);
             eventListener.RegisterEventHandler("AssetAccountPasswordUpdated", handler);
+            eventListener.RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
             Log.Debug("Event listener successfully created for Safeguard A2A context.");
             return eventListener;
         }

--- a/SafeguardDotNet/A2A/SafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/SafeguardA2AContext.cs
@@ -155,7 +155,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
             return json.Root.ToString().ToSecureString();
         }
 
-        public SecureString RetrievePrivateKey(SecureString apiKey, KeyFormat keyFormat)
+        public SecureString RetrievePrivateKey(SecureString apiKey, KeyFormat keyFormat = KeyFormat.OpenSsh)
         {
             if (_disposed)
                 throw new ObjectDisposedException("SafeguardA2AContext");

--- a/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
@@ -22,6 +22,7 @@ namespace OneIdentity.SafeguardDotNet.Event
                 throw new ArgumentException("Parameter may not be null", nameof(apiKey));
             _apiKey = apiKey.Copy();
             RegisterEventHandler("AssetAccountPasswordUpdated", handler);
+            RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
             Log.Debug("Persistent A2A event listener successfully created.");
         }
 
@@ -37,6 +38,7 @@ namespace OneIdentity.SafeguardDotNet.Event
             if (!_apiKeys.Any())
                 throw  new ArgumentException("Parameter must include at least one item", nameof(apiKeys));
             RegisterEventHandler("AssetAccountPasswordUpdated", handler);
+            RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
             Log.Debug("Persistent A2A event listener successfully created.");
         }
 

--- a/SafeguardDotNet/Event/SafeguardEventListener.cs
+++ b/SafeguardDotNet/Event/SafeguardEventListener.cs
@@ -148,8 +148,12 @@ namespace OneIdentity.SafeguardDotNet.Event
             {
                 _signalrConnection.Received += HandleEvent;
                 _signalrConnection.Closed += HandleDisconnect;
-                _signalrConnection.Start(_ignoreSsl ? new IgnoreSslValidationHttpClient() : (DefaultHttpClient)new CustomDelegateSslValidationHttpClient(_validationCallback))
-                    .Wait();
+                if (_ignoreSsl)
+                    _signalrConnection.Start(new IgnoreSslValidationHttpClient()).Wait();
+                else if (_validationCallback != null)
+                    _signalrConnection.Start(new CustomDelegateSslValidationHttpClient(_validationCallback)).Wait();
+                else
+                    _signalrConnection.Start(new DefaultHttpClient()).Wait();
                 _isStarted = true;
             }
             catch (Exception ex)

--- a/SafeguardDotNet/SafeguardDotNetTypes.cs
+++ b/SafeguardDotNet/SafeguardDotNetTypes.cs
@@ -50,7 +50,28 @@ namespace OneIdentity.SafeguardDotNet
         public string Body { get; set; }
     }
 
+    /// <summary>
+    /// A list of private key formats supported by Safeguard.
+    /// </summary>
+    public enum KeyFormat
+    {
+        /// <summary>
+        /// Legacy OpenSSH format (PKCS#1)
+        /// </summary>
+        OpenSsh,
+        /// <summary>
+        /// Tectia format compatible with SSH.com tools
+        /// </summary>
+        Ssh2,
+        /// <summary>
+        /// PuTTY format compatible with PuTTY ssh tools
+        /// </summary>
+        Putty
+    }
 
+    /// <summary>
+    /// A class representing the asset accounts that can be used with A2A credential retrieval.
+    /// </summary>
     public class A2ARetrievableAccount : IDisposable
     {
         public string ApplicationName { get; set; }

--- a/SafeguardDotNet/SafeguardDotNetTypes.cs
+++ b/SafeguardDotNet/SafeguardDotNetTypes.cs
@@ -56,15 +56,15 @@ namespace OneIdentity.SafeguardDotNet
     public enum KeyFormat
     {
         /// <summary>
-        /// Legacy OpenSSH format (PKCS#1)
+        /// OpenSSH legacy PEM format
         /// </summary>
         OpenSsh,
         /// <summary>
-        /// Tectia format compatible with SSH.com tools
+        /// Tectia format for use with tools from SSH.com
         /// </summary>
         Ssh2,
         /// <summary>
-        /// PuTTY format compatible with PuTTY ssh tools
+        /// Putty format for use with PuTTY tools
         /// </summary>
         Putty
     }

--- a/Test/SafeguardDotNetA2aTool/Program.cs
+++ b/Test/SafeguardDotNetA2aTool/Program.cs
@@ -96,8 +96,16 @@ namespace SafeguardDotNetA2aTool
                     }
                     else
                     {
-                        var responseBody = context.RetrievePassword(opts.ApiKey.ToSecureString());
-                        Log.Information(responseBody.ToInsecureString());
+                        if (opts.PrivateKey)
+                        {
+                            using (var responseBody = context.RetrievePrivateKey(opts.ApiKey.ToSecureString(), opts.KeyFormat))
+                                Log.Information(responseBody.ToInsecureString());
+                        }
+                        else
+                        {
+                            using (var responseBody = context.RetrievePassword(opts.ApiKey.ToSecureString()))
+                                Log.Information(responseBody.ToInsecureString());
+                        }
                     }
                 }
             }

--- a/Test/SafeguardDotNetA2aTool/ToolOptions.cs
+++ b/Test/SafeguardDotNetA2aTool/ToolOptions.cs
@@ -1,4 +1,6 @@
 ﻿using CommandLine;
+using CommandLine.Text;
+using OneIdentity.SafeguardDotNet;
 
 namespace SafeguardDotNetA2aTool
 {
@@ -39,5 +41,13 @@ namespace SafeguardDotNetA2aTool
         [Option('A', "ApiKey", Required = true, Default = null,
             HelpText = "ApiKey for call Safeguard A2A")]
         public string ApiKey { get; set; }
+
+        [Option('K', "PrivateKey", Required = false, Default = false,
+            HelpText = "Request private key rather than password")]
+        public bool PrivateKey { get; set; }
+
+        [Option('F', "KeyFormat", Required = false, Default = null,
+            HelpText = "Private key format to request")]
+        public KeyFormat KeyFormat { get; set; }
     }
 }


### PR DESCRIPTION
Support for pulling SSH private keys via the A2A API.
I also found and fixed an issue with TLS validation for A2A event listeners.