### PR TITLE
Add support for streaming uploads

### DIFF
--- a/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/AnonymousAuthenticator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Security;
+﻿using System.Net.Security;
 using System.Security;
 using RestSharp;
 

--- a/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
+++ b/SafeguardDotNet/Authentication/PasswordAuthenticator.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Linq;
-using System.Net;
 using System.Net.Security;
 using System.Security;
 using Newtonsoft.Json.Linq;
 using RestSharp;
-using Serilog;
 
 namespace OneIdentity.SafeguardDotNet.Authentication
 {

--- a/SafeguardDotNet/ISafeguardConnection.cs
+++ b/SafeguardDotNet/ISafeguardConnection.cs
@@ -70,6 +70,11 @@ namespace OneIdentity.SafeguardDotNet
             IDictionary<string, string> additionalHeaders = null);
 
         /// <summary>
+        /// Provides support for HTTP streaming requests
+        /// </summary>
+        IStreamingRequest Streaming { get; }
+
+        /// <summary>
         /// Gets a Safeguard event listener. You will need to call the RegisterEventHandler()
         /// method to establish callbacks. Then, you just have to call Start().  Call Stop()
         /// when you are finished. The event listener returned by this method WILL NOT

--- a/SafeguardDotNet/IStreamingRequest.cs
+++ b/SafeguardDotNet/IStreamingRequest.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OneIdentity.SafeguardDotNet
+{
+
+    /// <summary>
+    /// HTTP streaming request methods
+    /// </summary>
+    public interface IStreamingRequest
+    {
+        /// <summary>
+        /// Call a Safeguard POST API providing a stream as request content. If there is a 
+        /// failure a SafeguardDotNetException will be thrown.
+        /// </summary>
+        /// <param name="service">Safeguard service to call.</param>
+        /// <param name="relativeUrl">Relative URL of the service to use.</param>
+        /// <param name="stream">Stream to upload as request content.</param>
+        /// <param name="progress">Optionally report upload progress.</param>
+        /// <param name="parameters">Additional parameters to add to the URL.</param>
+        /// <param name="additionalHeaders">Additional headers to add to the request.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>Response body as a string.</returns>
+        Task<string> UploadAsync(Service service, string relativeUrl, Stream stream, IProgress<UploadProgress> progress = null, IDictionary<string, string> parameters = null, IDictionary<string, string> additionalHeaders = null, CancellationToken? cancellationToken = null);
+    }
+}

--- a/SafeguardDotNet/SafeguardDotNet.csproj
+++ b/SafeguardDotNet/SafeguardDotNet.csproj
@@ -37,7 +37,9 @@ Updates:
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RestSharp" Version="106.11.7" />

--- a/SafeguardDotNet/StreamingRequest.cs
+++ b/SafeguardDotNet/StreamingRequest.cs
@@ -1,0 +1,134 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using OneIdentity.SafeguardDotNet.Authentication;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Handlers;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OneIdentity.SafeguardDotNet
+{
+    internal class StreamingRequest : IStreamingRequest
+    {
+        const int DefaultBufferSize = 81920;
+        private readonly ProgressMessageHandler _progressMessageHandler = new ProgressMessageHandler();
+        private readonly IAuthenticationMechanism _authenticationMechanism;
+        private readonly Func<bool> _isDisposed;
+        private readonly Lazy<HttpClient> _lazyHttpClient;
+        private HttpClient Client => _lazyHttpClient.Value;
+
+        internal StreamingRequest(IAuthenticationMechanism authenticationMechanism, Func<bool> isDisposed)
+        {
+            _authenticationMechanism = authenticationMechanism;
+            _isDisposed = isDisposed;
+            _lazyHttpClient = new Lazy<HttpClient>(()=> CreateHttpClient(_progressMessageHandler));
+        }
+
+        public async Task<string> UploadAsync(Service service, string relativeUrl, Stream stream, IProgress<UploadProgress> progress = null, IDictionary<string, string> parameters = null, IDictionary<string, string> additionalHeaders = null, CancellationToken? cancellationToken = null)
+        {
+            if (_isDisposed())
+                throw new ObjectDisposedException("SafeguardConnection");
+            if (string.IsNullOrEmpty(relativeUrl))
+                throw new ArgumentException("Parameter may not be null or empty", nameof(relativeUrl));
+
+            var token = cancellationToken ?? CancellationToken.None;
+            var uri = $"https://{_authenticationMechanism.NetworkAddress}/service/{service}/v{_authenticationMechanism.ApiVersion}/{relativeUrl}";
+            if (parameters != null)
+            {
+                uri = QueryHelpers.AddQueryString(uri, parameters);
+            }
+
+            using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+            {
+                if (!_authenticationMechanism.IsAnonymous)
+                {
+                    if (!_authenticationMechanism.HasAccessToken())
+                        throw new SafeguardDotNetException("Access token is missing due to log out, you must refresh the access token to invoke a method");
+                    // SecureString handling here basically negates the use of a secure string anyway, but when calling a Web API
+                    // I'm not sure there is anything you can do about it.
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _authenticationMechanism.GetAccessToken().ToInsecureString());
+                }
+
+                if (additionalHeaders != null && !additionalHeaders.ContainsKey("Accept"))
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                if (additionalHeaders != null)
+                {
+                    foreach (var header in additionalHeaders)
+                        request.Headers.Add(header.Key, header.Value);
+                }
+
+                SafeguardConnection.LogRequestDetails(Method.Post, new Uri(uri), parameters, additionalHeaders);
+
+                EventHandler<HttpProgressEventArgs> progressHandlerFunc = null;
+
+                using (var content = new StreamContent(stream, DefaultBufferSize))
+                {
+                    request.Content = content;
+                    request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+                    if(progress != null)
+                    {
+                        progressHandlerFunc = (sender, args) =>
+                        {
+                            var uploadProgress = new UploadProgress
+                            {
+                                BytesTotal = args.TotalBytes.GetValueOrDefault(0),
+                                BytesTransferred = args.BytesTransferred
+                            };
+                            progress.Report(uploadProgress);
+                        };
+                        _progressMessageHandler.HttpSendProgress += progressHandlerFunc;
+                    }
+                    try
+                    {
+                        var response = await Client.SendAsync(request, completionOption: HttpCompletionOption.ResponseHeadersRead, token);
+
+                        var fullResponse = new FullResponse
+                        {
+                            Body = await response.Content.ReadAsStringAsync(),
+                            Headers = response.Headers.ToDictionary(key => key.Key, value => value.Value.FirstOrDefault()),
+                            StatusCode = response.StatusCode
+                        };
+
+                        if (!response.IsSuccessStatusCode)
+                            throw new SafeguardDotNetException(
+                                $"Error returned from Safeguard API, Error: {fullResponse.StatusCode} {fullResponse.Body}",
+                                fullResponse.StatusCode, fullResponse.Body);
+
+                        SafeguardConnection.LogResponseDetails(fullResponse);
+
+                        return fullResponse.Body;
+                    }
+                    finally
+                    {
+                        if(progressHandlerFunc != null)
+                        {
+                            _progressMessageHandler.HttpSendProgress -= progressHandlerFunc;
+                        }
+                    }
+                }
+            }
+        }
+
+        private HttpClient CreateHttpClient(ProgressMessageHandler progressHandler)
+        {
+            var httpClientHandler = new HttpClientHandler();
+            progressHandler.InnerHandler = httpClientHandler;
+            if (_authenticationMechanism.IgnoreSsl)
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+            }
+            else if (_authenticationMechanism.ValidationCallback != null)
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => _authenticationMechanism.ValidationCallback(message, cert, chain, errors);
+            }
+            
+            return new HttpClient(progressHandler); // do not dispose
+        }
+    }
+}

--- a/SafeguardDotNet/UploadProgress.cs
+++ b/SafeguardDotNet/UploadProgress.cs
@@ -1,0 +1,9 @@
+﻿namespace OneIdentity.SafeguardDotNet
+{
+    public class UploadProgress
+    {
+        public long BytesTransferred { get; set;  }
+        public long BytesTotal { get; set; }
+        public int PercentComplete => BytesTotal == 0 ? 0 : (int)((double)BytesTransferred / BytesTotal * 100);
+    }
+}

--- a/Test/SafeguardDotNetA2aTool/ToolOptions.cs
+++ b/Test/SafeguardDotNetA2aTool/ToolOptions.cs
@@ -1,5 +1,4 @@
 ﻿using CommandLine;
-using CommandLine.Text;
 using OneIdentity.SafeguardDotNet;
 
 namespace SafeguardDotNetA2aTool

--- a/Test/SafeguardDotNetTool/ToolOptions.cs
+++ b/Test/SafeguardDotNetTool/ToolOptions.cs
@@ -1,5 +1,4 @@
 ﻿using CommandLine;
-using CommandLine.Text;
 using OneIdentity.SafeguardDotNet;
 
 namespace SafeguardDotNetTool
@@ -69,5 +68,9 @@ namespace SafeguardDotNetTool
         [Option('C', "Csv", Required = false, Default = null,
             HelpText = "Request for a response as CSV")]
         public bool Csv { get; set; }
+
+        [Option('F', "File", Required = false, Default = null,
+            HelpText = "Path to a file to stream as the request body")]
+        public string File { get; set; }
     }
 }


### PR DESCRIPTION
Supports streaming uploads with progress. I wasn't able to use RestSharp for this (or I'm too dumb) so I've tried to implement it in a way that doesn't impact any of the existing code. There's a new streaming property on the ISafeguardConnection that gives access to the streaming functions which are implemented using the modern HttpClient and HttpRequestMessage.

Example code to upload a patch:

```csharp
// Connect as usual
ISafeguardConnection connection;

// Supports cancellation
CancellationTokenSource Cts;

// The stream to upload
using FileStream fs = File.OpenRead("patch.sgp");

// Supports progress
var progress = new Progress<UploadProgress>(p =>
{
    Console.Write("\rUploading: {0,3}% ({1}/{2})                                             ", p.PercentComplete, p.BytesTransferred, p.BytesTotal);
});

// Use the Streaming property to access streaming methods
responseBody = await connection.Streaming.UploadAsync(Service.Appliance, "Patch", fs, progress, cancellationToken: Cts.Token);
```

Demo:
![demo](https://user-images.githubusercontent.com/1326182/105776028-107d2e00-5f25-11eb-9d48-d7da0c095400.gif)
