### PR TITLE
Fix streaming error handling

### DIFF
--- a/SafeguardDotNet/StreamingRequest.cs
+++ b/SafeguardDotNet/StreamingRequest.cs
@@ -166,7 +166,6 @@ namespace OneIdentity.SafeguardDotNet
         {
             var fullResponse = new FullResponse
             {
-                Body = "<stream content>",
                 Headers = response.Headers.ToDictionary(key => key.Key, value => value.Value.FirstOrDefault()),
                 StatusCode = response.StatusCode
             };

--- a/SafeguardDotNet/StreamingRequest.cs
+++ b/SafeguardDotNet/StreamingRequest.cs
@@ -173,9 +173,12 @@ namespace OneIdentity.SafeguardDotNet
             // Check for 200 OK here because 204 Accepted doesn't return a stream,
             // better to fail in that case.
             if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                fullResponse.Body = response.Content.ReadAsStringAsync().Result;
                 throw new SafeguardDotNetException(
                     $"Response does not indicate OK status. Error: {fullResponse.StatusCode} {fullResponse.Body}",
                     fullResponse.StatusCode, fullResponse.Body);
+            }
 
             SafeguardConnection.LogResponseDetails(fullResponse);
         }


### PR DESCRIPTION
I didn't realize that SafeguardDotNetException attempts to parse the body here. If we get a non-200 result then read the body and set it so that error handling works as expected.