### PR TITLE
TFS 317508 Implement SafeguardDotNet code to download file from SPS

### DIFF
--- a/SafeguardDotNet/Sps/ISpsStreamingRequest.cs
+++ b/SafeguardDotNet/Sps/ISpsStreamingRequest.cs
@@ -20,5 +20,19 @@ namespace OneIdentity.SafeguardDotNet.Sps
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>Response body as a string.</returns>
         Task<string> UploadAsync(string relativeUrl, Stream stream, IProgress<TransferProgress> progress = null, IDictionary<string, string> parameters = null, IDictionary<string, string> additionalHeaders = null, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Call a Safeguard Sps GET API returning output as a stream. The caller takes ownership of the
+        /// StreamResponse and should dispose it when finished. Disposing the StreamResponse will dispose
+        /// the stream and related resources.
+        /// If there is a failure a SafeguardDotNetException will be thrown.
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL of the service to use.</param>
+        /// <param name="progress">Optionally report upload progress.</param>
+        /// <param name="parameters">Additional parameters to add to the URL.</param>
+        /// <param name="additionalHeaders">Additional headers to add to the request.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A StreamResponse. Call GetStream() to get the stream object.</returns>
+        Task<StreamResponse> DownloadStreamAsync(string relativeUrl, IProgress<TransferProgress> progress = null, IDictionary<string, string> parameters = null, IDictionary<string, string> additionalHeaders = null, CancellationToken? cancellationToken = null);
     }
 }


### PR DESCRIPTION
Add DownloadStreamAsync for SPS that will be used by Safeguard-Supervisor
code to download an SPS support bundle after it has been created.
DownloadStreamAsync for SPS is based on, and nearly identical, to
DownloadStreamAsync for SPP.