### PR TITLE
Listen for API key changes

### DIFF
--- a/SafeguardDotNet/A2A/SafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/SafeguardA2AContext.cs
@@ -234,6 +234,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
                 _clientCertificate, apiKey, _ignoreSsl, _validationCallback);
             eventListener.RegisterEventHandler("AssetAccountPasswordUpdated", handler);
             eventListener.RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
+            eventListener.RegisterEventHandler("AccountApiKeySecretUpdated", handler);
             Log.Debug("Event listener successfully created for Safeguard A2A context.");
             return eventListener;
         }
@@ -249,6 +250,7 @@ namespace OneIdentity.SafeguardDotNet.A2A
                 apiKeys, _ignoreSsl, _validationCallback);
             eventListener.RegisterEventHandler("AssetAccountPasswordUpdated", handler);
             eventListener.RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
+            eventListener.RegisterEventHandler("AccountApiKeySecretUpdated", handler);
             Log.Debug("Event listener successfully created for Safeguard A2A context.");
             return eventListener;
         }

--- a/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
+++ b/SafeguardDotNet/Event/PersistentSafeguardA2AEventListener.cs
@@ -23,6 +23,7 @@ namespace OneIdentity.SafeguardDotNet.Event
             _apiKey = apiKey.Copy();
             RegisterEventHandler("AssetAccountPasswordUpdated", handler);
             RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
+            RegisterEventHandler("AccountApiKeySecretUpdated", handler);
             Log.Debug("Persistent A2A event listener successfully created.");
         }
 
@@ -39,6 +40,7 @@ namespace OneIdentity.SafeguardDotNet.Event
                 throw  new ArgumentException("Parameter must include at least one item", nameof(apiKeys));
             RegisterEventHandler("AssetAccountPasswordUpdated", handler);
             RegisterEventHandler("AssetAccountSshKeyUpdated", handler);
+            RegisterEventHandler("AccountApiKeySecretUpdated", handler);
             Log.Debug("Persistent A2A event listener successfully created.");
         }
 


### PR DESCRIPTION
A2A context needs to return event listeners that are registered for API key events as well