### PR TITLE
TFS 403513: TD: Support PKCE in rSTS and stop using implicit flow from Safeguard clients

### DIFF
--- a/SafeguardDotNet.BrowserLogin/SafeguardDotNet.BrowserLogin.csproj
+++ b/SafeguardDotNet.BrowserLogin/SafeguardDotNet.BrowserLogin.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SafeguardDotNet.BrowserLogin/TokenExtractor.cs
+++ b/SafeguardDotNet.BrowserLogin/TokenExtractor.cs
@@ -32,7 +32,7 @@ namespace OneIdentity.SafeguardDotNet.BrowserLogin
             var accessTokenUri = $"https://{_appliance}/RSTS/Login?response_type=code&code_challenge_method=S256&code_challenge={Safeguard.OAuthCodeChallenge(CodeVerifier)}&redirect_uri={redirectUri}&port={port}";
            
             if (!string.IsNullOrEmpty(username))
-                redirectUri += $"&login_hint={HttpUtility.UrlEncode(username)}";
+                redirectUri += $"&login_hint={Uri.EscapeDataString(username)}";
             try
             {
                 var psi = new ProcessStartInfo { FileName = accessTokenUri, UseShellExecute = true };
@@ -44,7 +44,8 @@ namespace OneIdentity.SafeguardDotNet.BrowserLogin
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     accessTokenUri = accessTokenUri.Replace("&", "^&");
-                    Process.Start(new ProcessStartInfo("cmd", "/c start " + accessTokenUri) { CreateNoWindow = true });
+                    //Process.Start(new ProcessStartInfo("cmd", "/c start " + accessTokenUri) { CreateNoWindow = true });
+                    Process.Start(new ProcessStartInfo(accessTokenUri) { CreateNoWindow = true });
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {

--- a/SafeguardDotNet.BrowserLogin/TokenExtractor.cs
+++ b/SafeguardDotNet.BrowserLogin/TokenExtractor.cs
@@ -44,8 +44,7 @@ namespace OneIdentity.SafeguardDotNet.BrowserLogin
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     accessTokenUri = accessTokenUri.Replace("&", "^&");
-                    //Process.Start(new ProcessStartInfo("cmd", "/c start " + accessTokenUri) { CreateNoWindow = true });
-                    Process.Start(new ProcessStartInfo(accessTokenUri) { CreateNoWindow = true });
+                    Process.Start(new ProcessStartInfo(accessTokenUri));
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {

--- a/SafeguardDotNet.GuiLogin/LoginWindow.cs
+++ b/SafeguardDotNet.GuiLogin/LoginWindow.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Serilog;
+﻿using Serilog;
 
 namespace OneIdentity.SafeguardDotNet.GuiLogin
 {
@@ -22,17 +21,17 @@ namespace OneIdentity.SafeguardDotNet.GuiLogin
                     throw new SafeguardDotNetException("Unable to obtain authorization code");
                 }
 
-                Log.Debug("Posting RSTS access code to login response service");
+                Log.Debug("Redeeming RSTS authorization code");
 
-                using (var rstsAccessToken = Safeguard.PostAuthorizationCodeFlow(appliance, new Tuple<string, string>(rstsWindow.AuthorizationCode, rstsWindow.CodeVerifier), RedirectUri))
+                using (var rstsAccessToken = Safeguard.PostAuthorizationCodeFlow(appliance, rstsWindow.AuthorizationCode, rstsWindow.CodeVerifier, RedirectUri))
                 {
-                    Log.Debug("Posting RSTS access token to login response service");
+                    Log.Debug("Exchanging RSTS access token");
 
                     var responseObject = Safeguard.PostLoginResponse(appliance, rstsAccessToken);
 
                     var statusValue = responseObject.GetValue("Status")?.ToString();
 
-                    if (statusValue != null && !statusValue.Equals("Success"))
+                    if (string.IsNullOrEmpty(statusValue) || statusValue != "Success")
                     {
                         throw new SafeguardDotNetException($"Error response status {statusValue} from login response service");
                     }

--- a/SafeguardDotNet.GuiLogin/LoginWindow.cs
+++ b/SafeguardDotNet.GuiLogin/LoginWindow.cs
@@ -1,134 +1,51 @@
-﻿using System.Security;
-using Newtonsoft.Json.Linq;
-using RestSharp;
+﻿using System;
 using Serilog;
 
 namespace OneIdentity.SafeguardDotNet.GuiLogin
 {
     public static class LoginWindow
     {
-        private const int DefaultApiVersion = 3;
-
-        private const string ClientId = "00000000-0000-0000-0000-000000000000";
+        private const int DefaultApiVersion = 4;
         private const string RedirectUri = "urn:InstalledApplication";
-
-        private static RstsWindow _rstsWindow;
-
-        private static string ShowRstsWindow(string primaryProviderId = "", string secondaryProviderId = "")
-        {
-            if (_rstsWindow == null)
-            {
-                throw new SafeguardDotNetException("Please call primary rsts show method");
-            }
-            if (!_rstsWindow.Show(primaryProviderId, secondaryProviderId))
-            {
-                throw new SafeguardDotNetException("Unable to correctly manipulate browser");
-            }
-            if (string.IsNullOrEmpty(_rstsWindow.AuthorizationCode))
-            {
-                throw new SafeguardDotNetException("Unable to obtain authorization code");
-            }
-            return _rstsWindow.AuthorizationCode;
-        }
-
-        private static string ShowRstsWindowPrimary(string appliance)
-        {
-            _rstsWindow = new RstsWindow(appliance);
-            return ShowRstsWindow(appliance);
-        }
-
-        private static string ShowRstsWindowSecondary(string primaryProviderId = "", string secondaryProviderId = "")
-        {
-            var authorizationCode = ShowRstsWindow(primaryProviderId, secondaryProviderId);
-            _rstsWindow = null;
-            return authorizationCode;
-        }
-
-        private static SecureString PostAuthorizationCodeFlow(string appliance, string authorizationCode)
-        {
-            var safeguardRstsUrl = $"https://{appliance}/RSTS";
-            var rstsClient = new RestClient(safeguardRstsUrl,
-                options =>
-                {
-                    // The client would have already ignored certificate validation manually in the browser
-                    options.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
-                });
-
-            var request = new RestRequest("oauth2/token", RestSharp.Method.Post)
-                .AddHeader("Accept", "application/json")
-                .AddHeader("Content-type", "application/json")
-                .AddJsonBody(new
-                {
-                    grant_type = "authorization_code",
-                    client_id = ClientId,
-                    redirect_uri = RedirectUri,
-                    code = authorizationCode
-                });
-            var response = rstsClient.Execute(request);
-            if (response.ResponseStatus != ResponseStatus.Completed)
-                throw new SafeguardDotNetException($"Unable to connect to RSTS service {rstsClient.Options.BaseUrl}, Error: " +
-                                                   response.ErrorMessage);
-            if (!response.IsSuccessful)
-                throw new SafeguardDotNetException(
-                    "Error using authorization code grant_type, Error: " + $"{response.StatusCode} {response.Content}",
-                    response.StatusCode, response.Content);
-            var jObject = JObject.Parse(response.Content);
-            return jObject.GetValue("access_token")?.ToString().ToSecureString();
-        }
-
-        private static JObject PostLoginResponse(string appliance, SecureString rstsAccessToken)
-        {
-            var safeguardCoreUrl = $"https://{appliance}/service/core/v{DefaultApiVersion}";
-            var coreClient = new RestClient(safeguardCoreUrl,
-                options =>
-                {
-                    // The client would have already ignored certificate validation manually in the browser
-                    options.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
-                });
-            var request = new RestRequest("Token/LoginResponse", RestSharp.Method.Post)
-                .AddHeader("Accept", "application/json")
-                .AddHeader("Content-type", "application/json")
-                .AddJsonBody(new
-                {
-                    StsAccessToken = rstsAccessToken.ToInsecureString()
-                });
-            var response = coreClient.Execute(request);
-            if (response.ResponseStatus != ResponseStatus.Completed)
-                throw new SafeguardDotNetException($"Unable to connect to core service {coreClient.Options.BaseUrl}, Error: " +
-                                                   response.ErrorMessage);
-            if (!response.IsSuccessful)
-                throw new SafeguardDotNetException(
-                    "Error using authorization code grant_type, Error: " + $"{response.StatusCode} {response.Content}",
-                    response.StatusCode, response.Content);
-            return JObject.Parse(response.Content);
-        }
+        private static RstsWindow rstsWindow;
 
         public static ISafeguardConnection Connect(string appliance)
         {
             Log.Debug("Calling RSTS for primary authentication");
-            var authorizationCode = ShowRstsWindowPrimary(appliance);
-            using (var rstsAccessToken = PostAuthorizationCodeFlow(appliance, authorizationCode))
+
+            rstsWindow = new RstsWindow(appliance);
+
+            if (rstsWindow.Show())
             {
-                Log.Debug("Posting RSTS access token to login response service");
-                var responseObject = PostLoginResponse(appliance, rstsAccessToken);
-                var statusValue = responseObject.GetValue("Status")?.ToString();
-                if (statusValue != null && statusValue.Equals("Needs2FA"))
+                if (string.IsNullOrEmpty(rstsWindow.AuthorizationCode))
                 {
-                    Log.Debug("Authentication requires 2FA, continuing with RSTS for secondary authentication");
-                    authorizationCode = ShowRstsWindowSecondary(
-                        responseObject.GetValue("PrimaryProviderId")?.ToString(),
-                        responseObject.GetValue("SecondaryProviderId")?.ToString());
-                    using (var secondRstsAccessToken = PostAuthorizationCodeFlow(appliance, authorizationCode))
+                    throw new SafeguardDotNetException("Unable to obtain authorization code");
+                }
+
+                Log.Debug("Posting RSTS access code to login response service");
+
+                using (var rstsAccessToken = Safeguard.PostAuthorizationCodeFlow(appliance, new Tuple<string, string>(rstsWindow.AuthorizationCode, rstsWindow.CodeVerifier), RedirectUri))
+                {
+                    Log.Debug("Posting RSTS access token to login response service");
+
+                    var responseObject = Safeguard.PostLoginResponse(appliance, rstsAccessToken);
+
+                    var statusValue = responseObject.GetValue("Status")?.ToString();
+
+                    if (statusValue != null && !statusValue.Equals("Success"))
                     {
-                        Log.Debug("Posting second RSTS access token to login response service");
-                        responseObject = PostLoginResponse(appliance, secondRstsAccessToken);
-                        statusValue = responseObject.GetValue("Status")?.ToString();
+                        throw new SafeguardDotNetException($"Error response status {statusValue} from login response service");
+                    }
+
+                    using (var accessToken = responseObject.GetValue("UserToken")?.ToString().ToSecureString())
+                    {
+                        return Safeguard.Connect(appliance, accessToken, DefaultApiVersion, true);
                     }
                 }
-                if (statusValue != null && !statusValue.Equals("Success"))
-                    throw new SafeguardDotNetException($"Error response status {statusValue} from login response service");
-                using (var accessToken = responseObject.GetValue("UserToken")?.ToString().ToSecureString())
-                    return Safeguard.Connect(appliance, accessToken, DefaultApiVersion, true);
+            }
+            else
+            {
+                throw new SafeguardDotNetException("Unable to correctly manipulate browser");
             }
         }
     }

--- a/SafeguardDotNet.GuiLogin/RstsWindow.cs
+++ b/SafeguardDotNet.GuiLogin/RstsWindow.cs
@@ -48,7 +48,7 @@ namespace OneIdentity.SafeguardDotNet.GuiLogin
         {
             CodeVerifier = Safeguard.OAuthCodeVerifier();
 
-            var url = $"https://{_appliance}/RSTS/Login?response_type=code&code_challenge_method=S256&code_challenge={Safeguard.OAuthCodeChallenge(CodeVerifier)}&redirect_uri={HttpUtility.UrlEncode(RedirectUri)}";
+            var url = $"https://{_appliance}/RSTS/Login?response_type=code&code_challenge_method=S256&code_challenge={Safeguard.OAuthCodeChallenge(CodeVerifier)}&redirect_uri={Uri.EscapeDataString(RedirectUri)}";
 
             _browser.Stop();
             _browser.CoreWebView2.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
@@ -59,7 +59,11 @@ namespace OneIdentity.SafeguardDotNet.GuiLogin
         {
             var b = sender as Microsoft.Web.WebView2.Core.CoreWebView2;
 
-            if (Regex.IsMatch(b.DocumentTitle, "error=[^&]*|code=[^&]*"))
+            if (Regex.IsMatch(b.DocumentTitle, "error=[^&]*"))
+            {
+                throw new SafeguardDotNetException(b.DocumentTitle.Substring(6));
+            }
+            if (Regex.IsMatch(b.DocumentTitle, "code=[^&]*"))
             {
                 AuthorizationCode = b.DocumentTitle.Substring(5);
             }

--- a/SafeguardDotNet.GuiLogin/RstsWindow.cs
+++ b/SafeguardDotNet.GuiLogin/RstsWindow.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Web;
 using System.Windows.Forms;
 using Microsoft.Web.WebView2.WinForms;
 using Serilog;

--- a/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
+++ b/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,11 +37,17 @@
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.WebView2.Core, Version=1.0.1823.32, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.WebView2.WinForms, Version=1.0.1823.32, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.WebView2.Wpf, Version=1.0.1823.32, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="RestSharp, Version=110.2.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.110.2.0\lib\netstandard2.0\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.2.12.0\lib\net46\Serilog.dll</HintPath>
@@ -90,4 +98,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1823.32\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1823.32\build\Microsoft.Web.WebView2.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1823.32\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1823.32\build\Microsoft.Web.WebView2.targets'))" />
+  </Target>
 </Project>

--- a/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
+++ b/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
@@ -70,8 +70,8 @@
     <Reference Include="System.Text.Encodings.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encodings.Web.7.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.7.0.2\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=7.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.7.0.3\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
+++ b/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
@@ -50,7 +50,7 @@
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.12.0\lib\net46\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.3.0.1\lib\net462\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
+++ b/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.csproj
@@ -9,11 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OneIdentity.SafeguardDotNet.GuiLogin</RootNamespace>
     <AssemblyName>OneIdentity.SafeguardDotNet.GuiLogin</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,7 +51,7 @@
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.3.0.1\lib\net462\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.3.0.1\lib\net471\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.nuspec
+++ b/SafeguardDotNet.GuiLogin/SafeguardDotNet.GuiLogin.nuspec
@@ -16,17 +16,16 @@
     <copyright>(c) 2023 One Identity LLC. All rights reserved.</copyright>
     <tags>safeguard credentials vault sdk</tags>
     <dependencies>
-      <group targetFramework=".NETFramework4.6.2">
-        <dependency id="Newtonsoft.Json" version="(12.0.3, )" />
-        <dependency id="RestSharp" version="(106.10.1, )" />
-        <dependency id="Serilog" version="(2.9.0, )" />
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="Newtonsoft.Json" version="(13.0.3, )" />
+        <dependency id="Serilog" version="(3.0.1, )" />
       </group>
     </dependencies>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.6.2" />
-      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.6.2" />
-      <frameworkAssembly assemblyName="System.Web" targetFramework=".NETFramework4.6.2" />
-      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Web" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework=".NETFramework4.7.2" />
     </frameworkAssemblies>
   </metadata>
   <!--

--- a/SafeguardDotNet.GuiLogin/app.config
+++ b/SafeguardDotNet.GuiLogin/app.config
@@ -24,4 +24,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/SafeguardDotNet.GuiLogin/app.config
+++ b/SafeguardDotNet.GuiLogin/app.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+	</startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/SafeguardDotNet.GuiLogin/packages.config
+++ b/SafeguardDotNet.GuiLogin/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net462" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1823.32" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="RestSharp" version="110.2.0" targetFramework="net462" />
   <package id="Serilog" version="2.12.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />

--- a/SafeguardDotNet.GuiLogin/packages.config
+++ b/SafeguardDotNet.GuiLogin/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net462" />
-  <package id="Microsoft.Web.WebView2" version="1.0.1823.32" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Serilog" version="3.0.1" targetFramework="net462" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
-  <package id="System.Memory" version="4.5.5" targetFramework="net462" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
-  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net462" />
-  <package id="System.Text.Json" version="7.0.3" targetFramework="net462" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1823.32" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="Serilog" version="3.0.1" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="7.0.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/SafeguardDotNet.GuiLogin/packages.config
+++ b/SafeguardDotNet.GuiLogin/packages.config
@@ -9,7 +9,7 @@
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
   <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net462" />
-  <package id="System.Text.Json" version="7.0.2" targetFramework="net462" />
+  <package id="System.Text.Json" version="7.0.3" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
 </packages>

--- a/SafeguardDotNet.GuiLogin/packages.config
+++ b/SafeguardDotNet.GuiLogin/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net462" />
   <package id="Microsoft.Web.WebView2" version="1.0.1823.32" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="Serilog" version="2.12.0" targetFramework="net462" />
+  <package id="Serilog" version="3.0.1" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />

--- a/SafeguardDotNet.sln
+++ b/SafeguardDotNet.sln
@@ -28,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		build-publish.yml = build-publish.yml
 		build-test.yml = build-test.yml
+		Test\Invoke-SafeguardDotNetTests.ps1 = Test\Invoke-SafeguardDotNetTests.ps1
 		README.md = README.md
 		versionnumber.ps1 = versionnumber.ps1
 	EndProjectSection

--- a/SafeguardDotNet/Authentication/AuthenticatorBase.cs
+++ b/SafeguardDotNet/Authentication/AuthenticatorBase.cs
@@ -127,72 +127,51 @@ namespace OneIdentity.SafeguardDotNet.Authentication
         {
             try
             {
-                RestResponse response;
-                try
-                {
-                    var request = new RestRequest("UserLogin/LoginController", RestSharp.Method.Post)
-                        .AddHeader("Accept", "application/json")
-                        .AddHeader("Content-type", "application/x-www-form-urlencoded")
-                        .AddParameter("response_type", "token", ParameterType.QueryString)
-                        .AddParameter("redirect_uri", "urn:InstalledApplication", ParameterType.QueryString)
-                        .AddParameter("loginRequestStep", 1, ParameterType.QueryString)
-                        .AddJsonBody("RelayState=");
-                    response = RstsClient.Execute(request);
-                }
-                catch (WebException)
-                {
-                    Log.Debug("Caught exception with POST to find identity provider scopes, trying GET");
-                    var request = new RestRequest("UserLogin/LoginController", RestSharp.Method.Get)
-                        .AddHeader("Accept", "application/json")
-                        .AddHeader("Content-type", "application/x-www-form-urlencoded")
-                        .AddParameter("response_type", "token", ParameterType.QueryString)
-                        .AddParameter("redirect_uri", "urn:InstalledApplication", ParameterType.QueryString)
-                        .AddParameter("loginRequestStep", 1, ParameterType.QueryString);
-                    response = RstsClient.Execute(request);
-                }
+                var request = new RestRequest("AuthenticationProviders", RestSharp.Method.Get)
+                    .AddHeader("Accept", "application/json");
+                RestResponse response = CoreClient.Execute(request);
 
                 if (response.ResponseStatus != ResponseStatus.Completed)
                     throw new SafeguardDotNetException(
-                        "Unable to connect to RSTS to find identity provider scopes, Error: " +
+                        "Unable to connect to Core to find identity provider scopes, Error: " +
                         response.ErrorMessage);
                 if (!response.IsSuccessful)
                     throw new SafeguardDotNetException(
                         "Error requesting identity provider scopes from RSTS, Error: " +
                         $"{response.StatusCode} {response.Content}", response.StatusCode, response.Content);
-                var jObject = JObject.Parse(response.Content);
-                var jProviders = (JArray)jObject["Providers"];
-                var knownScopes = new List<(string Id, string DisplayName)>();
+                var jProviders = JArray.Parse(response.Content);
+                var knownScopes = new List<(string RstsProviderId, string Name, string RstsProviderScope)>();
                 if (jProviders != null)
-                    knownScopes = jProviders.Select(s => (Id: s["Id"].ToString(), DisplayName: s["DisplayName"].ToString())).ToList();
+                    knownScopes = jProviders.Select(s => (Id: s["RstsProviderId"].ToString(), Name: s["Name"].ToString(), Scope: s["RstsProviderScope"].ToString())).ToList();
 
                 // 3 step check for determining if the user provided scope is valid:
                 //
                 // 1. User value == RSTSProviderId
-                // 2. User value == Identity Provider Display Name.
+                // 2. User value == Identity Provider Name.
                 //    - This allows the caller to specify the domain name for AD.
                 // 3. User Value is contained in RSTSProviderId.
                 //    - This allows the caller to specify the provider Id rather than the full RSTSProviderId.
                 //    - Such a broad check could provide some issues with false matching, however since this
                 //      was in the original code, this check has been left in place.
-                var scope = knownScopes.FirstOrDefault(s => s.Id.EqualsNoCase(provider));
-                if (scope.Id == null)
-                { 
-                    scope = knownScopes.FirstOrDefault(s => s.DisplayName.EqualsNoCase(provider));
+                var scope = knownScopes.FirstOrDefault(s => s.RstsProviderId.EqualsNoCase(provider));
+                if (scope.RstsProviderId == null)
+                {
+                    scope = knownScopes.FirstOrDefault(s => s.Name.EqualsNoCase(provider));
 
-                    if (scope.DisplayName == null)
+                    if (scope.Name == null)
                     {
-                        scope = knownScopes.FirstOrDefault(s => s.Id.ContainsNoCase(provider));
+                        scope = knownScopes.FirstOrDefault(s => s.RstsProviderId.ContainsNoCase(provider));
 
-                        if (scope.Id == null)
+                        if (scope.RstsProviderId == null)
                         {
                             throw new SafeguardDotNetException(
                             $"Unable to find scope matching '{provider}' in [{string.Join(",", knownScopes)}]");
                         }
                     }
-                        
+
                 }
 
-                return $"rsts:sts:primaryproviderid:{scope.Id}";
+                return scope.RstsProviderScope;
             }
             catch (SafeguardDotNetException)
             {

--- a/SafeguardDotNet/Authentication/AuthenticatorBase.cs
+++ b/SafeguardDotNet/Authentication/AuthenticatorBase.cs
@@ -133,7 +133,7 @@ namespace OneIdentity.SafeguardDotNet.Authentication
 
                 if (response.ResponseStatus != ResponseStatus.Completed)
                     throw new SafeguardDotNetException(
-                        "Unable to connect to Core to find identity provider scopes, Error: " +
+                        "Unable to connect to RSTS to find identity provider scopes, Error: " +
                         response.ErrorMessage);
                 if (!response.IsSuccessful)
                     throw new SafeguardDotNetException(

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -936,7 +936,7 @@ namespace OneIdentity.SafeguardDotNet
             }
         }
 
-        public static SecureString PostAuthorizationCodeFlow(string appliance, Tuple<string, string> authorizationCode, string RedirectUri)
+        public static SecureString PostAuthorizationCodeFlow(string appliance, string authorizationCode, string codeVerifier, string RedirectUri)
         {
             var safeguardRstsUrl = $"https://{appliance}/RSTS";
             var rstsClient = new RestClient(safeguardRstsUrl,
@@ -953,8 +953,8 @@ namespace OneIdentity.SafeguardDotNet
                 {
                     grant_type = "authorization_code",
                     redirect_uri = RedirectUri,
-                    code = authorizationCode.Item1,
-                    code_verifier = authorizationCode.Item2
+                    code = authorizationCode,
+                    code_verifier = codeVerifier
                 });
 
             var response = rstsClient.Execute(request);

--- a/SafeguardDotNet/Safeguard.cs
+++ b/SafeguardDotNet/Safeguard.cs
@@ -1,9 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Security;
 using System.Security;
+using System.Security.Cryptography;
+using System.Text;
+using Newtonsoft.Json.Linq;
 using OneIdentity.SafeguardDotNet.A2A;
 using OneIdentity.SafeguardDotNet.Authentication;
 using OneIdentity.SafeguardDotNet.Event;
+using RestSharp;
 
 namespace OneIdentity.SafeguardDotNet
 {
@@ -929,6 +934,110 @@ namespace OneIdentity.SafeguardDotNet
                             false, validationCallback), apiKeys, handler);
                 }
             }
+        }
+
+        public static SecureString PostAuthorizationCodeFlow(string appliance, Tuple<string, string> authorizationCode, string RedirectUri)
+        {
+            var safeguardRstsUrl = $"https://{appliance}/RSTS";
+            var rstsClient = new RestClient(safeguardRstsUrl,
+                options =>
+                {
+                    // The client would have already ignored certificate validation manually in the browser
+                    options.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
+                });
+
+            var request = new RestRequest("oauth2/token", RestSharp.Method.Post)
+                .AddHeader("Accept", "application/json")
+                .AddHeader("Content-type", "application/json")
+                .AddJsonBody(new
+                {
+                    grant_type = "authorization_code",
+                    redirect_uri = RedirectUri,
+                    code = authorizationCode.Item1,
+                    code_verifier = authorizationCode.Item2
+                });
+
+            var response = rstsClient.Execute(request);
+
+            if (response.ResponseStatus != ResponseStatus.Completed)
+            {
+                throw new SafeguardDotNetException($"Unable to connect to RSTS service {rstsClient.Options.BaseUrl}, Error: " + response.ErrorMessage);
+            }
+
+            if (!response.IsSuccessful)
+            {
+                throw new SafeguardDotNetException("Error using authorization code grant_type, Error: " + $"{response.StatusCode} {response.Content}", response.StatusCode, response.Content);
+            }
+
+            var jObject = JObject.Parse(response.Content);
+            return jObject.GetValue("access_token")?.ToString().ToSecureString();
+        }
+
+        public static JObject PostLoginResponse(string appliance, SecureString rstsAccessToken)
+        {
+            var safeguardCoreUrl = $"https://{appliance}/service/core/v{DefaultApiVersion}";
+
+            var coreClient = new RestClient(safeguardCoreUrl,
+                options =>
+                {
+                    // The client would have already ignored certificate validation manually in the browser
+                    options.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
+                });
+
+            var request = new RestRequest("Token/LoginResponse", RestSharp.Method.Post)
+                .AddHeader("Accept", "application/json")
+                .AddHeader("Content-type", "application/json")
+                .AddJsonBody(new
+                {
+                    StsAccessToken = rstsAccessToken.ToInsecureString()
+                });
+
+            var response = coreClient.Execute(request);
+
+            if (response.ResponseStatus != ResponseStatus.Completed && response.ResponseStatus != ResponseStatus.Error)
+            {
+                throw new SafeguardDotNetException($"Unable to connect to core service {coreClient.Options.BaseUrl}, Error: " + response.ErrorMessage);
+            }
+
+            if (!response.IsSuccessful)
+            {
+                throw new SafeguardDotNetException("Error using authorization code grant_type, Error: " + $"{response.StatusCode} {response.Content}", response.StatusCode, response.Content);
+            }
+
+            return JObject.Parse(response.Content);
+        }
+
+        public static string OAuthCodeVerifier()
+        {
+            var bytes = new byte[60];
+            RandomNumberGenerator.Create().GetBytes(bytes);
+            return ToBase64Url(bytes);
+        }
+
+        public static string OAuthCodeChallenge(string codeVerifier)
+        {
+            using (var sha = SHA256.Create())
+            {
+                var hash = sha.ComputeHash(Encoding.ASCII.GetBytes(codeVerifier));
+
+                return ToBase64Url(hash);
+            }
+        }
+
+        // https://172.21.21.1/RSTS/Login?
+        // response_type=code&
+        // redirect_uri=https%3a%2f%2flocalhost%3a7035%2f%3fserver%3d172.21.21.1%26auth%3dresume&
+        // code_challenge=Ullteua8nkpbqkCUpKSxqPfTqrZvZfnmpV3YTGEPUfQ&
+        // code_challenge_method=S256&
+        // state=w5mtmJUPPMhHEW-qo4PyyX4pGDsevgTN2QNRC0aWiaxd8weEQdgiHoieLe4NDeuAkL63Q6-ipG1nIOwY
+
+        /// <summary>Creates a Base64 string with the trailing equal signs removed and any plus signs replaced with
+        /// minus signs and any forward slashes replaced with underscores.</summary>
+        /// <param name="data">Any byte array to be Base64 encoded.</param>
+        /// <returns>A special Base64 string that is URL safe. Used in JWTs, OAuth2.0 and other things.</returns>
+        public static string ToBase64Url(byte[] data)
+        {
+            return Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_');
         }
     }
 }

--- a/SafeguardDotNet/SafeguardDotNet.csproj
+++ b/SafeguardDotNet/SafeguardDotNet.csproj
@@ -44,7 +44,7 @@ Updates:
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
 

--- a/Samples/SampleA2aService/SampleA2aService.csproj
+++ b/Samples/SampleA2aService/SampleA2aService.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.2.0" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />

--- a/Samples/SampleA2aService/SampleA2aService.csproj
+++ b/Samples/SampleA2aService/SampleA2aService.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.1.0" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />

--- a/Samples/ServiceNowTicketValidator/ServiceNowClient.cs
+++ b/Samples/ServiceNowTicketValidator/ServiceNowClient.cs
@@ -51,7 +51,7 @@ namespace ServiceNowTicketValidator
                 EnsureRestClient();
                 var request =
                     new RestRequest($"api/now/table/incident?sysparm_query=number%3D{ticketNumber}&sysparm_limit=1",
-                        Method.GET);
+                        Method.Get);
                 HandleHeaders(ref request);
                 var response = _restClient.Execute<ServiceNowResult<ServiceNowIncident>>(request);
                 return response?.Data?.result?.FirstOrDefault();
@@ -96,11 +96,14 @@ namespace ServiceNowTicketValidator
 
         private RestClient GetRestClient()
         {
-            var restClient = _restClient ?? new RestClient(_applicationUrl);
-            if (UseBasicAuth)
-                restClient.Authenticator = new HttpBasicAuthenticator(_userName, _password.ToInsecureString());
-            else
-                HandleOAuth();
+            var restClient = _restClient ?? new RestClient(_applicationUrl, options =>
+            {
+                if (UseBasicAuth)
+                    options.Authenticator = new HttpBasicAuthenticator(_userName, _password.ToInsecureString());
+                else
+                    HandleOAuth();
+            });
+
             return restClient;
         }
 

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
@@ -85,7 +85,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="OneIdentity.SafeguardDotNet">
-      <Version>7.2.0</Version>
+      <Version>7.3.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>3.0.1</Version>

--- a/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
+++ b/Samples/ServiceNowTicketValidator/ServiceNowTicketValidator.csproj
@@ -88,7 +88,7 @@
       <Version>7.2.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.12.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.Console">
       <Version>4.1.0</Version>

--- a/Test/SafeguardDotNetA2aTool/SafeguardDotNetA2aTool.csproj
+++ b/Test/SafeguardDotNetA2aTool/SafeguardDotNetA2aTool.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="ObjectDumper.NET" Version="4.0.6" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 

--- a/Test/SafeguardDotNetAccessRequestBrokerTool/SafeguardDotNetAccessRequestBrokerTool.csproj
+++ b/Test/SafeguardDotNetAccessRequestBrokerTool/SafeguardDotNetAccessRequestBrokerTool.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 

--- a/Test/SafeguardDotNetBrowserLoginTester/SafeguardDotNetBrowserLoginTester.csproj
+++ b/Test/SafeguardDotNetBrowserLoginTester/SafeguardDotNetBrowserLoginTester.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 

--- a/Test/SafeguardDotNetEventTool/SafeguardDotNetEventTool.csproj
+++ b/Test/SafeguardDotNetEventTool/SafeguardDotNetEventTool.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 

--- a/Test/SafeguardDotNetExceptionTest/SafeguardDotNetExceptionTest.csproj
+++ b/Test/SafeguardDotNetExceptionTest/SafeguardDotNetExceptionTest.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 

--- a/Test/SafeguardDotNetGuiTester/App.config
+++ b/Test/SafeguardDotNetGuiTester/App.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.2" newVersion="7.0.0.2" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.3" newVersion="7.0.0.3" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
+++ b/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
@@ -70,5 +70,8 @@
       <Name>SafeguardDotNet</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="RestSharp" Version="110.2.0" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
+++ b/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
@@ -34,9 +34,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -65,6 +62,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CommandLineParser">
+      <Version>2.9.1</Version>
+    </PackageReference>
     <PackageReference Include="RestSharp" Version="110.2.0.0" />
     <PackageReference Include="Serilog.Sinks.Console">
       <Version>4.1.0</Version>

--- a/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
+++ b/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
@@ -37,9 +37,6 @@
     <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.12.0\lib\net47\Serilog.dll</HintPath>
-    </Reference>
     <Reference Include="Serilog.Sinks.Console, Version=4.1.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.Console.4.1.0\lib\net45\Serilog.Sinks.Console.dll</HintPath>
     </Reference>
@@ -69,9 +66,6 @@
       <Project>{e2a99b0b-7037-4ff0-aecd-c3afae5b068f}</Project>
       <Name>SafeguardDotNet</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
+++ b/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
@@ -37,6 +37,9 @@
     <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.3.0.1\lib\net471\Serilog.dll</HintPath>
+    </Reference>
     <Reference Include="Serilog.Sinks.Console, Version=4.1.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.Console.4.1.0\lib\net45\Serilog.Sinks.Console.dll</HintPath>
     </Reference>
@@ -66,6 +69,9 @@
       <Project>{e2a99b0b-7037-4ff0-aecd-c3afae5b068f}</Project>
       <Name>SafeguardDotNet</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="RestSharp" Version="110.2.0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
+++ b/Test/SafeguardDotNetGuiTester/SafeguardDotNetGuiTester.csproj
@@ -37,12 +37,6 @@
     <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.3.0.1\lib\net471\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.Sinks.Console, Version=4.1.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.Console.4.1.0\lib\net45\Serilog.Sinks.Console.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -72,6 +66,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="110.2.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console">
+      <Version>4.1.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Test/SafeguardDotNetGuiTester/packages.config
+++ b/Test/SafeguardDotNetGuiTester/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.9.1" targetFramework="net472" />
+  <package id="CommandLine" version="2.9.1" targetFramework="net472" />
   <package id="Serilog" version="3.0.1" targetFramework="net472" />
   <package id="Serilog.Sinks.Console" version="4.1.0" targetFramework="net472" />
 </packages>

--- a/Test/SafeguardDotNetGuiTester/packages.config
+++ b/Test/SafeguardDotNetGuiTester/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="2.9.1" targetFramework="net472" />
-  <package id="Serilog" version="2.12.0" targetFramework="net472" />
+  <package id="Serilog" version="3.0.1" targetFramework="net472" />
   <package id="Serilog.Sinks.Console" version="4.1.0" targetFramework="net472" />
 </packages>

--- a/Test/SafeguardDotNetTool/SafeguardDotNetTool.csproj
+++ b/Test/SafeguardDotNetTool/SafeguardDotNetTool.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 

--- a/Test/SafeguardSessionsDotNetTool/SafeguardSessionsDotNetTool.csproj
+++ b/Test/SafeguardSessionsDotNetTool/SafeguardSessionsDotNetTool.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
TFS 421334: Update SafeguardDotNet.BrowserLogin to use PKCE
TFS 421332: Update SafeguardDotNet.GuiLogin to use PKCE

Update GuiLogin to use the new WebView2 instead of older WebBrowser.
Move some common code into SafeguardDotNet instead of duplicating in GuiLogin and BrowserLogin.
Update RstsProviderScope to use Core/AuthenticationProviders endpoint.
Update from v3 to v4.

Clean up some pipeline build issues around conflicting older assembly versions i.e. CommandLine and Serilog.Sinks.Console and convert those to newer nuget packages.

Consolidate GuiLogin and GuiTester from 4.6.2 into 4.7.2 and samples SafeguardDotNet nuget 7.3.