### PR TITLE
Keep the session cookie at the client level

### DIFF
--- a/SafeguardDotNet/Sps/SafeguardSessionsConnection.cs
+++ b/SafeguardDotNet/Sps/SafeguardSessionsConnection.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using RestSharp;
 using RestSharp.Authenticators;
-using System.Security;
 using System.Net;
-using Serilog;
 using System;
+using System.Net.Http;
 
 namespace OneIdentity.SafeguardDotNet.Sps
 {
@@ -36,6 +35,14 @@ namespace OneIdentity.SafeguardDotNet.Sps
                 {
                     options.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
                 }
+
+                options.ConfigureMessageHandler = h =>
+                {
+                    var handler = (HttpClientHandler)h;
+                    handler.CookieContainer = options.CookieContainer;
+                    handler.UseCookies = true;
+                    return handler;
+                };
             });
 
             var authRequest = new RestRequest("authentication", RestSharp.Method.Get);


### PR DESCRIPTION
With the upgrade of RestSharp, it no longer retains cookies on the client level. This fix just instructs the client to revert to the previous behavior.