### PR TITLE
Update RestSharp NuGet Package

### DIFF
--- a/SafeguardDotNet/SafeguardConnection.cs
+++ b/SafeguardDotNet/SafeguardConnection.cs
@@ -114,8 +114,7 @@ namespace OneIdentity.SafeguardDotNet
             }
             if (timeout.HasValue)
             {
-                request.Timeout = (timeout.Value.TotalMilliseconds > int.MaxValue)
-                    ? int.MaxValue : (int)timeout.Value.TotalMilliseconds;
+                request.Timeout = timeout.Value;
             }
 
             var client = GetClientForService(service);

--- a/SafeguardDotNet/SafeguardDotNet.csproj
+++ b/SafeguardDotNet/SafeguardDotNet.csproj
@@ -40,10 +40,10 @@ Updates:
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Update the RestSharp NuGet package reference to version 112, which fixes a CRLF header vulnerability: https://github.com/advisories/GHSA-4rr6-2v9v-wcpc
https://github.com/restsharp/RestSharp/releases/tag/112.0.0