### PR TITLE
Set A2A Password

### DIFF
--- a/SafeguardDotNet/A2A/SafeguardA2AContext.cs
+++ b/SafeguardDotNet/A2A/SafeguardA2AContext.cs
@@ -163,8 +163,10 @@ namespace OneIdentity.SafeguardDotNet.A2A
             if (password == null)
                 throw new ArgumentException("Parameter may not be null", nameof(password));
 
+            var data = JsonConvert.SerializeObject(password.ToInsecureString());
+
             var request = new RestRequest("Credentials/Password", RestSharp.Method.Put)
-                .AddParameter("application/json", $"\"{password.ToInsecureString()}\"", ParameterType.RequestBody)
+                .AddParameter("application/json", data, ParameterType.RequestBody)
                 .AddHeader("Accept", "application/json")
                 .AddHeader("Authorization", $"A2A {apiKey.ToInsecureString()}");
             var response = _a2AClient.Execute(request);


### PR DESCRIPTION
Fixes issue #189. When calling the `PUT` method of the A2A `Credentials/Password` API, the code was taking the password value and blindly wrapping it in double quotes to try and make a JSON string object. But that would fail if the password value had a double quote character itself or other things.

So now, we properly serialize the password string value to a JSON string, with proper escaping.