### PR TITLE
chore: add .worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,3 +333,6 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 /packages/
+
+# Worktrees
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` directory to `.gitignore` to support git worktree-based development workflows.

This prevents worktree directories from being accidentally committed to the repository.