### PR TITLE
Modernize pipeline: trunk-based dev, tag releases, GitHub Releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require review from SafeguardPasswords team for all changes
+* @OneIdentity/SafeguardPasswords

--- a/build.yml
+++ b/build.yml
@@ -143,4 +143,7 @@ jobs:
       isPreRelease: $(isPrerelease)
       changeLogCompareToRelease: 'lastFullRelease'
       changeLogType: 'commitBased'
+      assets: |
+        $(Build.ArtifactStagingDirectory)/*.nupkg
+        $(Build.ArtifactStagingDirectory)/*.snupkg
     displayName: 'Creating GitHub Release'

--- a/build.yml
+++ b/build.yml
@@ -4,22 +4,31 @@ variables:
 trigger:
   branches:
     include:
+    - main
     - master
     - release-*
+  tags:
+    include:
+    - 'v*'
   paths:
     exclude:
-    - README.md
-    - AGENTS.md
+    - '**/*.md'
+    - LICENSE
+    - docs/
+    - .github/CODEOWNERS
 
 pr:
   branches:
     include:
+    - main
     - master
     - release-*
   paths:
     exclude:
-    - README.md
-    - AGENTS.md
+    - '**/*.md'
+    - LICENSE
+    - docs/
+    - .github/CODEOWNERS
 
 jobs:
 # Job 1: PR Validation - runs only on pull requests
@@ -121,3 +130,17 @@ jobs:
       command: 'custom'
       arguments: 'push $(Build.ArtifactStagingDirectory)\*.nupkg -source https://api.nuget.org/v3/index.json -ApiKey $(NugetOrgApiKey) -NonInteractive -Verbosity detailed'
     displayName: 'Publishing NuGet packages to NuGet.org'
+
+  - task: GitHubRelease@1
+    inputs:
+      gitHubConnection: 'PangaeaBuild-GitHub'
+      repositoryName: 'OneIdentity/SafeguardDotNet'
+      action: 'create'
+      target: '$(Build.SourceVersion)'
+      tagSource: 'userSpecifiedTag'
+      tag: '$(ReleaseTag)'
+      title: '$(ReleaseTag)'
+      isPreRelease: $(isPrerelease)
+      changeLogCompareToRelease: 'lastFullRelease'
+      changeLogType: 'commitBased'
+    displayName: 'Creating GitHub Release'

--- a/pipeline-templates/build-steps.yml
+++ b/pipeline-templates/build-steps.yml
@@ -2,8 +2,8 @@ steps:
 - task: PowerShell@2
   inputs:
     targetType: filePath
-    filePath: $(System.DefaultWorkingDirectory)\versionnumber.ps1
-    arguments: $(Build.SourcesDirectory) $(semanticVersion) $(Build.BuildId) $$(isPrerelease)
+    filePath: $(System.DefaultWorkingDirectory)\pipeline-templates\versionnumber.ps1
+    arguments: $(Build.SourcesDirectory) $(semanticVersion) $(Build.BuildId) $$(isPrerelease) $(Build.SourceBranchName) $(isTagBuild)
   displayName: 'Setting build version'
 
 - task: Bash@3

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,5 +1,10 @@
 variables:
   - name: semanticVersion
     value: '8.2.3'
+  - name: isTagBuild
+    value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease
-    value: ${{ true }}
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
+      value: false
+    ${{ else }}:
+      value: true

--- a/pipeline-templates/versionnumber.ps1
+++ b/pipeline-templates/versionnumber.ps1
@@ -7,11 +7,19 @@ Param(
     [Parameter(Mandatory=$true, Position=2)]
     [string]$BuildId,
     [Parameter(Mandatory=$true, Position=3)]
-    [bool]$IsPrerelease
+    [bool]$IsPrerelease,
+    [Parameter(Mandatory=$false, Position=4)]
+    [string]$TagName = "",
+    [Parameter(Mandatory=$false, Position=5)]
+    [string]$IsTagBuild = "False"
 )
+
+$local:IsTagBuildBool = $IsTagBuild -eq "True"
 
 Write-Host "SemanticVersion = $SemanticVersion"
 Write-Host "BuildId = $BuildId"
+Write-Host "TagName = $TagName"
+Write-Host "IsTagBuild = $IsTagBuild"
 
 # Build number must be between 0 - 65534
 $local:BuildNumber = $BuildId % 65534
@@ -20,41 +28,57 @@ Write-Host "BuildNumber = $($local:BuildNumber)"
 
 $local:PackageCodeMarker = "9999.9999.9999"
 $local:AssemblyCodeMarker = "9999.9999.9999.9999"
-$local:AssemblyVersion = "${SemanticVersion}.$($local:BuildNumber)"
-if ($IsPrerelease)
+
+if ($local:IsTagBuildBool)
 {
-    $local:PackageVersion = "${SemanticVersion}-dev-$($local:BuildNumber)"
+    # Validate tag format
+    if ($TagName -notmatch '^v\d+\.\d+\.\d+$')
+    {
+        Write-Error "ERROR: Tag '$TagName' does not match expected format 'v<major>.<minor>.<patch>'. Aborting release build."
+        exit 1
+    }
+    $local:TagVersion = $TagName -replace '^v', ''
+    $local:PackageVersion = $local:TagVersion
+    $local:AssemblyVersion = "${local:TagVersion}.$($local:BuildNumber)"
+    $local:ReleaseTag = $TagName
+    Write-Host "Tag build detected, using tag name as version"
 }
 else
 {
-    $local:PackageVersion = $SemanticVersion
+    $local:AssemblyVersion = "${SemanticVersion}.$($local:BuildNumber)"
+    $local:PackageVersion = "${SemanticVersion}-pre$($local:BuildNumber)"
+    $local:ReleaseTag = "dev/v$($local:PackageVersion)"
+    Write-Host "Dev build"
 }
 Write-Host "PackageCodeMarker = $($local:PackageCodeMarker)"
 Write-Host "AssemblyCodeMarker = $($local:AssemblyCodeMarker)"
 Write-Host "PackageVersion = $($local:PackageVersion)"
 Write-Host "AssemblyVersion = $($local:AssemblyVersion)"
 
+$local:RepoRoot = $SourceDir
+
 Write-Host "Replacing markers in SafeguardDotNet"
-$local:ProjectFile = (Join-Path $PSScriptRoot "SafeguardDotNet\SafeguardDotNet.csproj")
+$local:ProjectFile = (Join-Path $local:RepoRoot "SafeguardDotNet\SafeguardDotNet.csproj")
 (Get-Content $local:ProjectFile -Raw).replace($local:AssemblyCodeMarker, $local:AssemblyVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:ProjectFile
 (Get-Content $local:ProjectFile -Raw).replace($local:PackageCodeMarker, $local:PackageVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:ProjectFile
 
 Write-Host "Replacing markers in SafeguardDotNet.BrowserLogin"
-$local:ProjectFile = (Join-Path $PSScriptRoot "SafeguardDotNet.BrowserLogin\SafeguardDotNet.BrowserLogin.csproj")
+$local:ProjectFile = (Join-Path $local:RepoRoot "SafeguardDotNet.BrowserLogin\SafeguardDotNet.BrowserLogin.csproj")
 (Get-Content $local:ProjectFile -Raw).replace($local:AssemblyCodeMarker, $local:AssemblyVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:ProjectFile
 (Get-Content $local:ProjectFile -Raw).replace($local:PackageCodeMarker, $local:PackageVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:ProjectFile
 
 Write-Host "Replacing markers in SafeguardDotNet.PkceNoninteractiveLogin"
-$local:ProjectFile = (Join-Path $PSScriptRoot "SafeguardDotNet.PkceNoninteractiveLogin\SafeguardDotNet.PkceNoninteractiveLogin.csproj")
+$local:ProjectFile = (Join-Path $local:RepoRoot "SafeguardDotNet.PkceNoninteractiveLogin\SafeguardDotNet.PkceNoninteractiveLogin.csproj")
 (Get-Content $local:ProjectFile -Raw).replace($local:AssemblyCodeMarker, $local:AssemblyVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:ProjectFile
 (Get-Content $local:ProjectFile -Raw).replace($local:PackageCodeMarker, $local:PackageVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:ProjectFile
 
 Write-Host "Replacing markers in SafeguardDotNet.GuiLogin"
-$local:GuiAssemblyInfoFile = (Join-Path $PSScriptRoot "SafeguardDotNet.GuiLogin\Properties\AssemblyInfo.cs")
-$local:GuiNuspec = (Join-Path $PSScriptRoot "SafeguardDotNet.GuiLogin\SafeguardDotNet.GuiLogin.nuspec")
+$local:GuiAssemblyInfoFile = (Join-Path $local:RepoRoot "SafeguardDotNet.GuiLogin\Properties\AssemblyInfo.cs")
+$local:GuiNuspec = (Join-Path $local:RepoRoot "SafeguardDotNet.GuiLogin\SafeguardDotNet.GuiLogin.nuspec")
 (Get-Content $local:GuiAssemblyInfoFile -Raw).replace($local:AssemblyCodeMarker, $local:AssemblyVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:GuiAssemblyInfoFile
 (Get-Content $local:GuiNuspec -Raw).replace($local:PackageCodeMarker, $local:PackageVersion).TrimEnd() | Set-Content -Encoding UTF8 $local:GuiNuspec
 
 
 Write-Output "##vso[task.setvariable variable=AssemblyVersion;]$($local:AssemblyVersion)"
 Write-Output "##vso[task.setvariable variable=PackageVersion;]$($local:PackageVersion)"
+Write-Output "##vso[task.setvariable variable=ReleaseTag;]$($local:ReleaseTag)"


### PR DESCRIPTION
## Summary

Modernize SafeguardDotNet CI/CD pipeline for trunk-based development with tag-based releases.

### Changes

- **Triggers**: Add `main` branch and `v*` tag triggers alongside existing `master`/`release-*`
- **Path exclusions**: Broaden to all markdown files, LICENSE, docs/, CODEOWNERS
- **Version logic**: Add `isTagBuild` variable; derive `isPrerelease` from branch/tag context
- **versionnumber.ps1**: Tag-based release mode with `^v\d+\.\d+\.\d+$` validation, change dev suffix from `-dev-` to `-pre` for SemVer consistency, output `ReleaseTag` variable
- **File reorg**: Move `versionnumber.ps1` to `pipeline-templates/` for root cleanup
- **GitHub Releases**: Add `GitHubRelease@1` task to `BuildAndPublish` job (uses `ReleaseTag` for both tag and title)
- **CODEOWNERS**: Add `.github/CODEOWNERS` for SafeguardPasswords team

### Version Format Changes

| Build Type | Before | After |
|---|---|---|
| Dev/prerelease | `8.2.3-dev-12345` | `8.2.3-pre12345` |
| Tag release | `8.2.3` | `8.2.3` (from `v8.2.3` tag) |

### GitHub Release Tags

| Build Type | Tag | Title |
|---|---|---|
| Dev | `dev/v8.2.3-pre12345` | `dev/v8.2.3-pre12345` |
| Release | `v8.2.3` | `v8.2.3` |

No ADO-side changes required until branch rename (post-merge).