### PR TITLE
Skills harmonization: rename architecture, add api-patterns, build-and-release, a2a-workflow

### DIFF
--- a/.agents/skills/a2a-workflow/SKILL.md
+++ b/.agents/skills/a2a-workflow/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: a2a-workflow
+description: Use when working with Safeguard A2A certificate auth, credential retrieval, brokering, or A2A event listeners.
+---
+
+# A2A Workflow
+Safeguard A2A (Application-to-Application) is the SDK surface for unattended,
+certificate-based integrations. In this repo, `Safeguard.A2A.GetContext(...)`
+creates an `ISafeguardA2AContext` that talks to `/service/A2A/v<apiVersion>/...`
+with a client certificate plus an A2A API key. It is used for retrieving passwords,
+SSH keys, API key secrets, brokering access requests, and subscribing to A2A
+credential-change events.
+## 1. What A2A is (one-paragraph context)
+
+A2A is the automation-friendly side of Safeguard. Unlike normal `Safeguard.Connect()`
+flows that authenticate a user and then send bearer tokens, A2A uses a client
+certificate to establish trust and an `Authorization: A2A <apiKey>` header to scope
+credential retrieval or brokering to a configured registration. The SDK models this
+with `ISafeguardA2AContext`, `SafeguardA2AContext`, `A2ARetrievableAccount`,
+`BrokeredAccessRequest`, and `ApiKeySecret`.
+## 2. Setup flow (certificate registration, API key creation)
+
+The repository does not create A2A registrations for you; that setup happens on the
+Safeguard appliance. The codebase shows the expected appliance-side shape.
+
+### Appliance-side prerequisites
+
+1. Register a client certificate for the integration.
+2. Create one or more A2A registrations tied to that certificate user.
+3. Assign retrievable accounts and/or brokering rights.
+4. Generate the A2A API key that will be used for retrieval or brokering.
+
+### SDK context creation patterns
+
+`Safeguard.A2A.GetContext(...)` supports the same three certificate sources used by
+other certificate-based SDK entry points:
+
+- certificate store thumbprint
+- PFX/PKCS#12 file + password
+- in-memory certificate bytes + password
+
+Examples:
+
+```csharp
+using var context = Safeguard.A2A.GetContext(
+    appliance,
+    thumbprint,
+    apiVersion: 4,
+    ignoreSsl: true);
+```
+
+```csharp
+using var context = Safeguard.A2A.GetContext(
+    appliance,
+    certificatePath,
+    certificatePassword,
+    apiVersion: 4,
+    ignoreSsl: true);
+```
+
+```csharp
+var bytes = File.ReadAllBytes(certificatePath);
+using var context = Safeguard.A2A.GetContext(
+    appliance,
+    bytes,
+    certificatePassword,
+    apiVersion: 4,
+    ignoreSsl: true);
+```
+
+Validation-callback overloads also exist when you want custom certificate validation
+instead of `ignoreSsl`.
+
+### Enumerating registrations and API keys
+
+`Samples\SampleA2aService\SampleService.cs` shows a practical discovery flow:
+
+1. Create a normal certificate-backed `ISafeguardConnection`
+2. Query `Service.Core` `A2ARegistrations`
+3. Filter by `CertificateUserThumbprint`
+4. Query `A2ARegistrations/{id}/RetrievableAccounts`
+5. Read the returned `ApiKey` values and cache them as `SecureString`
+
+That sample uses:
+
+```csharp
+var a2AJson = _connection.InvokeMethod(
+    Service.Core,
+    Method.Get,
+    "A2ARegistrations",
+    parameters: new Dictionary<string, string>
+    {
+        ["filter"] = $"CertificateUserThumbprint ieq '{thumbprint}'",
+    });
+```
+
+Important setup notes pulled from the repo:
+
+- `ISafeguardA2AContext.GetRetrievableAccounts()` is documented as a Safeguard v2.8+
+  feature that must be enabled in the A2A configuration.
+- The sample comments note that enumerating registrations by certificate user may
+  require auditor permission.
+- `SampleA2aService` throws if no API keys are found after enumeration.
+
+## 3. Credential retrieval (programmatic access)
+
+### Primary retrieval methods on `ISafeguardA2AContext`
+
+| Method | Purpose |
+|---|---|
+| `GetRetrievableAccounts()` / `GetRetrievableAccounts(filter)` | Discover accessible accounts and API keys |
+| `RetrievePassword(apiKey)` | Fetch a password as `SecureString` |
+| `SetPassword(apiKey, password)` | Rotate/update a password |
+| `RetrievePrivateKey(apiKey, keyFormat)` | Fetch an SSH private key |
+| `SetPrivateKey(apiKey, privateKey, password, keyFormat)` | Upload/update an SSH private key |
+| `RetrieveApiKeySecret(apiKey)` | Fetch API key secret material as `IList<ApiKeySecret>` |
+
+### Transport details
+
+`SafeguardA2AContext` uses these routes internally:
+
+- `GET Core/A2ARegistrations`
+- `GET Core/A2ARegistrations/{id}/RetrievableAccounts`
+- `GET A2A/Credentials?type=Password`
+- `PUT A2A/Credentials/Password`
+- `GET A2A/Credentials?type=PrivateKey&keyFormat=<format>`
+- `PUT A2A/Credentials/SshKey?keyFormat=<format>`
+- `GET A2A/Credentials?type=ApiKey`
+
+The context sends:
+
+- `Accept: application/json`
+- `Authorization: A2A <apiKey>` when an API key is required
+- the client certificate on the TLS connection
+
+### Typical password retrieval pattern
+
+```csharp
+using var context = Safeguard.A2A.GetContext(appliance, thumbprint, apiVersion: 4, ignoreSsl: true);
+using var password = context.RetrievePassword(apiKey.ToSecureString());
+
+var clearText = password.ToInsecureString();
+```
+
+### Discovering retrievable accounts
+
+`Test\SafeguardDotNetA2aTool` uses `GetRetrievableAccounts()` in two modes:
+
+- no filter -> enumerate everything visible to the registration
+- SCIM-style filter -> e.g. `AccountName eq 'admin'`
+
+The filter is applied server-side to each registration's retrievable-accounts endpoint.
+
+### API key secret retrieval
+
+`RetrieveApiKeySecret()` returns `ApiKeySecret` objects whose `ClientSecret` is a
+`SecureString`. Dispose them when you are done.
+
+### Secure disposal expectations
+
+- `ApiKeySecret` implements `IDisposable`
+- `A2ARetrievableAccount.ApiKey` is treated as sensitive data
+- certificate passwords and retrieved credentials should stay in `SecureString`
+- top-level services such as `SampleA2aService` dispose listeners, connections, and
+  A2A contexts during shutdown
+
+## 4. Brokering (if supported)
+
+Yes. `ISafeguardA2AContext.BrokerAccessRequest()` posts a `BrokeredAccessRequest`
+object to `A2A/AccessRequests`.
+
+### Minimum required fields
+
+`SafeguardA2AContext` enforces these before the HTTP call:
+
+- one of `ForUserId` or `ForUserName`
+- one of `AssetId` or `AssetName`
+
+If either is missing, it throws `SafeguardDotNetException` before contacting the
+server.
+
+### Useful optional fields from `BrokeredAccessRequest`
+
+- `AccessType` (`Password`, `Ssh`, `Rdp`)
+- `AccountId` / `AccountName`
+- `AccountAssetId` / `AccountAssetName`
+- `ReasonCodeId` / `ReasonCode`
+- `ReasonComment`
+- `TicketNumber`
+- `RequestedFor`
+- `RequestedDuration`
+
+`Test\SafeguardDotNetAccessRequestBrokerTool` shows the intended calling pattern:
+
+```csharp
+using var context = CreateA2AContext(opts);
+var accessRequest = GetBrokeredAccessRequestObject(opts);
+var json = context.BrokerAccessRequest(opts.ApiKey.ToSecureString(), accessRequest);
+```
+
+The tool accepts either IDs or names for user, asset, account, and reason code, then
+maps numeric strings to the `*Id` properties.
+
+## 5. Event listeners / SignalR (if supported)
+
+Yes. A2A supports both non-persistent and persistent SignalR listeners.
+
+### Context-based listener APIs
+
+| Method | Recovery behavior |
+|---|---|
+| `GetA2AEventListener(apiKey, handler)` | Does **not** recover from a 30+ second outage |
+| `GetA2AEventListener(apiKeys, handler)` | Same, but for multiple API keys |
+| `GetPersistentA2AEventListener(apiKey, handler)` | Reconnects automatically |
+| `GetPersistentA2AEventListener(apiKeys, handler)` | Reconnects automatically |
+
+### Static helper APIs
+
+`Safeguard.A2A.Event.GetPersistentA2AEventListener(...)` exposes the same persistent
+listener pattern directly from:
+
+- thumbprint-based certificate auth
+- certificate file + password
+- in-memory certificate bytes + password
+- optional validation-callback overloads
+- single API key or multiple API keys
+
+### Event names actually registered
+
+The implementation registers handlers for three A2A events:
+
+- `AssetAccountPasswordUpdated`
+- `AssetAccountSshKeyUpdated`
+- `AccountApiKeySecretUpdated`
+
+This is worth knowing because some XML comments still describe only the password
+update event.
+
+### Reconnect behavior
+
+Persistent A2A listeners are backed by `PersistentSafeguardA2AEventListener`, which
+inherits the shared reconnect loop from `PersistentSafeguardEventListenerBase`:
+
+- reconnect work runs in the background
+- failures log a warning and sleep for 5 seconds
+- the listener retries until reconnection succeeds or stop/dispose is requested
+
+Use the persistent variant for Windows services, daemon-style workloads, or anything
+that must survive appliance/network interruptions.
+
+### Sample patterns in this repo
+
+- `Samples\SampleA2aService\SampleService.cs` starts one persistent listener per API key
+- `Test\SafeguardDotNetEventTool` supports single-key, multi-key, and "discover all keys"
+  flows before starting a listener
+- both patterns call `Start()` explicitly after creating the listener
+
+## 6. Error scenarios and troubleshooting
+
+### Common argument/setup failures
+
+- No certificate input -> the CLI tools throw `InvalidOperationException("Must specify CertificateFile or Thumbprint")`
+- Null `apiKey`, `password`, `privateKey`, or `accessRequest` -> `ArgumentException`
+- Empty API key set for multi-key listeners -> `ArgumentException`
+- Missing user or asset in brokered requests -> `SafeguardDotNetException`
+
+### HTTP/API failures
+
+`SafeguardA2AContext.ApiRequest()` throws `SafeguardDotNetException` when Safeguard
+returns a non-success HTTP status. The exception includes status and raw response
+content, so inspect `HttpStatusCode`, `ErrorMessage`, and `Response`.
+
+### Timeouts and retries
+
+- one-shot retrieval/brokering calls do **not** include an automatic retry loop
+- timeout surfaces as `SafeguardDotNetException("Request timeout to ...")`
+- retry policy for `RetrievePassword()`, `RetrievePrivateKey()`, or `BrokerAccessRequest()`
+  is the caller's responsibility
+- only persistent SignalR listeners auto-reconnect
+
+### SSL troubleshooting
+
+- `ignoreSsl` bypasses certificate validation and is intended for dev/test only
+- production integrations should prefer trusted certificates or a validation callback
+- the same certificate source pattern is reused across normal SDK connections and A2A
+
+### Registration discovery troubleshooting
+
+If registration enumeration fails in the sample flow, check:
+
+- whether the certificate thumbprint matches the A2A registration's certificate user
+- whether the registration has retrievable accounts configured
+- whether the appliance version/config supports `GetRetrievableAccounts()`
+- whether the caller has permission to enumerate `A2ARegistrations`
+
+If you only need retrieval and already have a valid API key, skip the Core registration
+lookup and call the A2A context methods directly.

--- a/.agents/skills/api-patterns/SKILL.md
+++ b/.agents/skills/api-patterns/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: api-patterns
+description: Use when making standard Safeguard Web API calls with ISafeguardConnection and related SDK helpers.
+---
+
+# API Patterns
+
+Use this skill when you need to turn a Safeguard REST operation into the normal
+SafeguardDotNet calling pattern. The SDK keeps the public surface intentionally
+small: choose a connection factory from `Safeguard`, then dispatch with
+`ISafeguardConnection.InvokeMethod()`, `InvokeMethodFull()`, `InvokeMethodCsv()`,
+or the A2A-specific context.
+
+## 1. Service/endpoint enumeration
+
+`Service` in `SafeguardDotNetTypes.cs` is the dispatch switch for standard API calls:
+
+| Service | What it is for | Standard base URL |
+|---|---|---|
+| `Service.Core` | Cluster-wide product APIs: users, assets, policies, requests, A2A registrations | `https://<appliance>/service/core/v<apiVersion>/` |
+| `Service.Appliance` | Appliance-local operations such as maintenance and diagnostics | `https://<appliance>/service/appliance/v<apiVersion>/` |
+| `Service.Notification` | Anonymous/read-only status style endpoints | `https://<appliance>/service/notification/v<apiVersion>/` |
+| `Service.A2A` | Reserved enum member; `SafeguardConnection` rejects it for normal `InvokeMethod()` calls | Use `Safeguard.A2A.GetContext()` instead |
+| `Service.Management` | DR/support operations on the management service | Call `connection.GetManagementServiceConnection()` first |
+
+Operational rules:
+
+- `Safeguard.DefaultApiVersion` is `4`.
+- `SafeguardConnection` only routes `Core`, `Appliance`, and `Notification`.
+- `Service.A2A` throws `SafeguardDotNetException("You must call the A2A service using the A2A specific method")`.
+- Management requests require a derived connection created with
+  `ISafeguardConnection.GetManagementServiceConnection(string networkAddress)`.
+- Swagger is still the easiest endpoint catalog: browse
+  `https://<address>/service/<service>/swagger` and then translate the operation into
+  `Service + Method + relativeUrl`.
+
+## 2. URL construction or method dispatch
+
+`SafeguardConnection` builds absolute service roots in its constructor and combines
+those with your relative endpoint path at request time.
+
+### Method surface
+
+Only four HTTP verbs are exposed by the public `Method` enum:
+
+- `Method.Get`
+- `Method.Post`
+- `Method.Put`
+- `Method.Delete`
+
+Use the simplest dispatcher that matches the task:
+
+- `InvokeMethod()` -> body string only
+- `InvokeMethodFull()` -> `FullResponse` with `StatusCode`, `Headers`, and `Body`
+- `InvokeMethodCsv()` -> forces `Accept: text/csv`
+- `connection.Streaming.*` -> file upload/download flows, not normal JSON CRUD
+
+### Relative URL rules
+
+- Pass paths like `Me`, `Assets`, or `Users/123/Password`.
+- Do **not** include the service prefix or API version; the SDK adds those.
+- Do **not** include a leading `/`. The implementation strips one as a compatibility
+  workaround, but new code should avoid relying on that cleanup.
+
+### Query parameters and headers
+
+Use the optional dictionaries instead of string-building URLs by hand:
+
+```csharp
+var query = new Dictionary<string, string>
+{
+    ["filter"] = "CertificateUserThumbprint ieq '756766BB590D7FA9CA9E1971A4AE41BB9CEC82F1'",
+};
+
+var headers = new Dictionary<string, string>
+{
+    ["X-Correlation-ID"] = Guid.NewGuid().ToString(),
+};
+
+var json = connection.InvokeMethod(
+    Service.Core,
+    Method.Get,
+    "A2ARegistrations",
+    parameters: query,
+    additionalHeaders: headers);
+```
+
+Implementation details that matter:
+
+- `SafeguardConnection.AddQueryParameters()` URL-escapes both keys and values.
+- If you do not set `Accept`, `InvokeMethodFull()` assumes JSON and adds
+  `Accept: application/json`.
+- `POST` and `PUT` bodies are always sent as UTF-8 `application/json`.
+- `InvokeMethodCsv()` injects `Accept: text/csv` before dispatching.
+
+### When you need the full envelope
+
+Use `InvokeMethodFull()` when callers need headers or status code in addition to
+JSON content:
+
+```csharp
+var response = connection.InvokeMethodFull(
+    Service.Core,
+    Method.Get,
+    "Me");
+
+Console.WriteLine((int)response.StatusCode);
+Console.WriteLine(response.Body);
+```
+
+The `Test\SafeguardDotNetTool` CLI mirrors this pattern behind its `-f` switch.
+
+## 3. Authentication context for API calls
+
+The SDK has multiple connection factories on `Safeguard`:
+
+- anonymous: `Safeguard.Connect(appliance)`
+- username/password: `Safeguard.Connect(appliance, provider, username, password, ...)`
+- client certificate by thumbprint, file, or byte array
+- existing access token: `Safeguard.Connect(appliance, accessToken, ...)`
+
+What happens after connect:
+
+- Non-anonymous calls add `Authorization: Bearer <token>` automatically.
+- Anonymous connections skip the bearer header and are limited to endpoints that
+  really support anonymous access.
+- SSL behavior lives on the authentication mechanism and is reused by the HTTP
+  client and event listeners.
+- `LogOut()` posts to `Core/Token/Logout` and then clears the cached token.
+
+For long-running automation, wrap the connection:
+
+```csharp
+using var baseConnection = Safeguard.Connect(appliance, "local", username, password, apiVersion: 4, ignoreSsl: true);
+using var connection = Safeguard.Persist(baseConnection);
+
+var me = connection.InvokeMethod(Service.Core, Method.Get, "Me");
+```
+
+`PersistentSafeguardConnection` checks `GetAccessTokenLifetimeRemaining() <= 0`
+before each call and runs `RefreshAccessToken()` automatically. That is the only
+built-in retry-like behavior for standard API traffic.
+
+## 4. CRUD examples (standard patterns)
+
+### Read
+
+```csharp
+var meJson = connection.InvokeMethod(Service.Core, Method.Get, "Me");
+```
+
+For an anonymous health-style call, use the notification service instead:
+
+```csharp
+using var anon = Safeguard.Connect(appliance, apiVersion: 4, ignoreSsl: true);
+var statusJson = anon.InvokeMethod(Service.Notification, Method.Get, "Status");
+```
+
+### Create
+
+The repository README uses this pattern to create an asset:
+
+```csharp
+var createdAsset = connection.InvokeMethod(
+    Service.Core,
+    Method.Post,
+    "Assets",
+    JsonConvert.SerializeObject(new
+    {
+        Name = "linux.blue.vas",
+        NetworkAddress = "linux.blue.vas",
+        Description = "A new linux asset",
+        PlatformId = 188,
+        AssetPartitionId = -1,
+    }));
+```
+
+### Update
+
+Two common update styles appear in the repo:
+
+```csharp
+connection.InvokeMethod(
+    Service.Core,
+    Method.Put,
+    $"Users/{userId}/Password",
+    JsonConvert.SerializeObject("MyNewUser123"));
+```
+
+```csharp
+context.SetPassword(apiKey, newPassword);
+context.SetPrivateKey(apiKey, privateKey, passphrase, KeyFormat.OpenSsh);
+```
+
+### Delete
+
+The transport pattern is identical; choose `Method.Delete` and a relative URL that
+Swagger confirms supports deletion:
+
+```csharp
+connection.InvokeMethod(Service.Core, Method.Delete, $"Assets/{assetId}");
+```
+
+### Action-style POST endpoints
+
+Not every `POST` is a create. Samples use action endpoints such as:
+
+```csharp
+connection.InvokeMethod(Service.Core, Method.Post, $"AccessRequests/{accessRequestId}/Approve");
+connection.InvokeMethod(Service.Core, Method.Post, $"AccessRequests/{accessRequestId}/Deny");
+```
+
+Treat these as command endpoints discovered from Swagger or existing samples, not as
+plain resource creation.
+
+## 5. Error handling and retry behavior
+
+Every standard HTTP failure is normalized to `SafeguardDotNetException`.
+
+What you get back on failure:
+
+- `HttpStatusCode` when the server replied
+- `Response` with the raw body
+- `ErrorCode` parsed from JSON `Code` when present
+- `ErrorMessage` parsed from JSON `Message` or `error`, otherwise the raw response text
+
+Common failure sources:
+
+- non-success HTTP status -> `SafeguardDotNetException(message, status, response)`
+- `HttpRequestException` -> wrapped as `SafeguardDotNetException(..., innerException)`
+- request timeout / cancellation -> `SafeguardDotNetException("Request timeout to ...")`
+- disposed objects -> `ObjectDisposedException`
+- unsupported service usage -> `SafeguardDotNetException`
+
+Recommended handling pattern:
+
+```csharp
+try
+{
+    var json = connection.InvokeMethod(Service.Core, Method.Get, "Me");
+}
+catch (SafeguardDotNetException ex)
+{
+    Log.Error("Status={Status} Code={Code} Message={Message} Body={Body}",
+        ex.HttpStatusCode,
+        ex.ErrorCode,
+        ex.ErrorMessage,
+        ex.Response);
+    throw;
+}
+```
+
+Retry guidance:
+
+- There is **no** general HTTP retry loop in `SafeguardConnection`.
+- Caller code must decide whether a failed GET/POST/PUT/DELETE is safe to retry.
+- `Safeguard.Persist()` only handles expired access tokens, not transient 5xx/429 errors.
+- Persistent SignalR listeners reconnect separately; that behavior does not apply to
+  one-shot REST calls.
+
+## 6. Swagger/OpenAPI integration
+
+This repository does **not** generate a typed client from OpenAPI. The workflow is:
+
+1. Open Swagger at `https://<address>/service/<service>/swagger`.
+2. Find the operation, verb, path, query parameters, and body schema.
+3. Map the service name to the SDK `Service` enum.
+4. Pass the path after `/v<apiVersion>/` as `relativeUrl`.
+5. Serialize the request body with `JsonConvert.SerializeObject(...)` when needed.
+
+Useful repository-backed examples:
+
+- `README.md` shows create/update examples for core resources.
+- `Samples\SampleA2aService\SampleService.cs` shows filtered `A2ARegistrations`
+  enumeration through `Service.Core`.
+- `Test\SafeguardDotNetTool` is the generic reproducer for ad hoc API dispatch.
+
+If an endpoint belongs to `/service/a2a/...`, switch mental models: consult Swagger,
+then implement it through `Safeguard.A2A.GetContext()` and `ISafeguardA2AContext`
+instead of `ISafeguardConnection`.

--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: architecture-deep-dive
+name: architecture
 description: >-
   Use when working on SDK internals, authentication mechanisms, connection
   classes, PKCE login flow, rSTS protocol details, event listeners, A2A
@@ -8,7 +8,7 @@ description: >-
   step flow, and SignalR event architecture.
 ---
 
-# Architecture Deep Dive
+# Architecture
 
 ## Exploring the Safeguard API
 

--- a/.agents/skills/build-and-release/SKILL.md
+++ b/.agents/skills/build-and-release/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: build-and-release
+description: Use when reproducing SafeguardDotNet CI/CD, version stamping, signing, packaging, or release publishing.
+---
+
+# Build and Release
+
+Use this skill for Azure Pipelines changes, local CI reproduction, package version
+questions, or release troubleshooting. SafeguardDotNet has a split build: legacy
+.NET Framework projects are built with MSBuild first, then the modern SDK-style
+projects are built and packed with the dotnet CLI.
+
+## 1. Pipeline architecture (files, stages, triggers)
+
+### Primary files
+
+| File | Purpose |
+|---|---|
+| `build.yml` | Top-level pipeline definition, triggers, and job selection |
+| `pipeline-templates\global-variables.yml` | Shared semantic version and tag/prerelease flags |
+| `pipeline-templates\job-variables.yml` | Solution paths and build configuration |
+| `pipeline-templates\build-steps.yml` | Shared restore/build/pack/artifact flow used by both jobs |
+| `pipeline-templates\versionnumber.ps1` | Replaces placeholder versions and sets Azure Pipeline variables |
+| `Directory.Build.props` | Analyzer/code-style requirements enforced during build |
+
+### Triggers
+
+`build.yml` runs on:
+
+- pushes to `main`, `master`, and `release-*`
+- tags matching `v*`
+- pull requests targeting `main`, `master`, and `release-*`
+
+It deliberately ignores documentation-only changes:
+
+- `**/*.md`
+- `LICENSE`
+- `docs/`
+- `.github/CODEOWNERS`
+
+### Jobs
+
+#### `PRValidation`
+
+Runs only when `Build.Reason == PullRequest`.
+
+- imports `job-variables.yml`
+- sets `signFiles: false`
+- uses `windows-latest`
+- runs only `pipeline-templates\build-steps.yml`
+- does **not** fetch signing or publishing secrets
+
+#### `BuildAndPublish`
+
+Runs for non-PR builds after merges and tags.
+
+- imports `job-variables.yml`
+- sets `signFiles: true`
+- uses `windows-latest`
+- pulls signing secrets from Azure Key Vault
+- installs/configures SSL.com eSignerCKA
+- resolves x86 `signtool.exe`
+- runs the shared `build-steps.yml`
+- pulls the NuGet.org API key
+- pushes packages to NuGet.org
+- creates a GitHub release with package assets
+
+### Shared build flow from `build-steps.yml`
+
+1. Run `versionnumber.ps1`
+2. Dump environment variables for diagnostics
+3. Ensure the .NET Framework 4.8.1 Developer Pack exists
+4. Install NuGet tooling
+5. Restore `SafeguardDotNet.Framework.sln` with NuGet.exe
+6. Restore `SafeguardDotNet\SafeguardDotNet.csproj` with `dotnet restore`
+7. Resolve the x86 Windows SDK `signtool.exe` path
+8. Build `SafeguardDotNet.Framework.sln` with MSBuild
+9. Install .NET SDK `10.0.x`
+10. Build `SafeguardDotNet.Core.sln` with `dotnet build`
+11. Verify Authenticode signatures when signing is enabled
+12. Pack three SDK-style projects with `dotnet pack`
+13. Pack `SafeguardDotNet.GuiLogin.nuspec` with NuGet
+14. Publish the artifact staging directory as build artifacts
+
+## 2. Version strategy (how version numbers are derived)
+
+### Source of truth
+
+`pipeline-templates\global-variables.yml` currently sets:
+
+```yaml
+semanticVersion: '8.2.3'
+```
+
+The pipeline also computes:
+
+- `isTagBuild` -> true when `Build.SourceBranch` starts with `refs/tags/`
+- `isPrerelease` -> false for tag builds, true otherwise
+
+### Placeholder markers in source
+
+The repo keeps placeholder values in source control and stamps real versions in CI:
+
+| File(s) | Package marker | Assembly marker |
+|---|---|---|
+| `SafeguardDotNet\SafeguardDotNet.csproj` | `9999.9999.9999` | `9999.9999.9999.9999` |
+| `SafeguardDotNet.BrowserLogin\SafeguardDotNet.BrowserLogin.csproj` | `9999.9999.9999` | `9999.9999.9999.9999` |
+| `SafeguardDotNet.PkceNoninteractiveLogin\SafeguardDotNet.PkceNoninteractiveLogin.csproj` | `9999.9999.9999` | `9999.9999.9999.9999` |
+| `SafeguardDotNet.GuiLogin\SafeguardDotNet.GuiLogin.nuspec` | `9999.9999.9999` | n/a |
+| `SafeguardDotNet.GuiLogin\Properties\AssemblyInfo.cs` | n/a | `9999.9999.9999.9999` |
+
+Do not hand-edit these markers for normal development.
+
+### `versionnumber.ps1` rules
+
+The script computes:
+
+- `BuildNumber = BuildId % 65534`
+- validates tag builds against `^v\d+\.\d+\.\d+$`
+
+For tag builds:
+
+- package version = tag without leading `v`
+- assembly version = `<tagVersion>.<BuildNumber>`
+- release tag = original Git tag (for example `v8.2.3`)
+
+For non-tag builds:
+
+- package version = `<semanticVersion>-pre<BuildNumber>`
+- assembly version = `<semanticVersion>.<BuildNumber>`
+- release tag = `dev/v<packageVersion>`
+
+The script also exports Azure variables:
+
+- `AssemblyVersion`
+- `PackageVersion`
+- `ReleaseTag`
+
+## 3. Build commands (local reproduction)
+
+### Day-to-day developer build
+
+For normal SDK work, this is the common local command:
+
+```powershell
+dotnet build SafeguardDotNet.Core.sln /p:SignFiles=false
+```
+
+### Closer reproduction of pipeline behavior
+
+Use these commands when you need something nearer to CI, while still skipping
+cloud signing dependencies:
+
+```powershell
+nuget restore SafeguardDotNet.Framework.sln
+
+dotnet restore SafeguardDotNet\SafeguardDotNet.csproj
+
+msbuild SafeguardDotNet.Framework.sln /p:Configuration=Release /p:SignFiles=false
+
+dotnet build SafeguardDotNet.Core.sln --configuration Release /p:SignFiles=false
+
+dotnet pack SafeguardDotNet\SafeguardDotNet.csproj --configuration Release --include-symbols -p:SymbolPackageFormat=snupkg --output .\artifacts --no-build
+
+dotnet pack SafeguardDotNet.BrowserLogin\SafeguardDotNet.BrowserLogin.csproj --configuration Release --include-symbols -p:SymbolPackageFormat=snupkg --output .\artifacts --no-build
+
+dotnet pack SafeguardDotNet.PkceNoninteractiveLogin\SafeguardDotNet.PkceNoninteractiveLogin.csproj --configuration Release --include-symbols -p:SymbolPackageFormat=snupkg --output .\artifacts --no-build
+
+nuget pack SafeguardDotNet.GuiLogin\SafeguardDotNet.GuiLogin.nuspec -Properties Configuration=Release -Symbols -SymbolPackageFormat snupkg -OutputDirectory .\artifacts
+```
+
+Important local constraints:
+
+- Always pass `/p:SignFiles=false` locally unless you have the exact signing setup.
+- The pipeline installs the .NET Framework 4.8.1 Developer Pack explicitly; local
+  Windows machines must have it to build `SafeguardDotNet.Framework.sln`.
+- `Directory.Build.props` enforces StyleCop and Sonar analyzers, so warning-free
+  builds are expected.
+
+### What not to reproduce locally unless necessary
+
+Avoid trying to mimic these pipeline-only steps on a normal workstation unless you
+already own the required access:
+
+- Azure Key Vault secret retrieval
+- SSL.com eSignerCKA certificate loading
+- x86 signtool-based Authenticode signing with CI credentials
+- NuGet.org push
+- GitHub release publication
+
+## 4. Publishing targets (registry, signing)
+
+### Authenticode signing
+
+Signing is assembly-level, not package-level.
+
+- The release job downloads and installs SSL.com eSignerCKA.
+- It configures the signing account using Azure Key Vault secrets.
+- It loads the certificate into `Cert:\CurrentUser\My`.
+- It resolves an **x86** `signtool.exe` because the eSignerCKA PKCS#11 DLL is 32-bit only.
+- Each SDK-style project has a `SignAssemblies` target that signs `$(TargetDir)*.dll`
+  when `SignFiles=true`.
+- `build-steps.yml` verifies every built `OneIdentity.SafeguardDotNet*.dll` signature.
+
+There is an explicit pipeline note that NuGet package signing is **not** performed:
+
+- eSignerCKA exposes only a 32-bit PKCS#11 DLL on Windows
+- available NuGet signing tools are 64-bit
+- the DLLs inside the packages are already Authenticode-signed instead
+
+### Produced packages
+
+Release builds publish four packages plus symbol packages:
+
+| Artifact | Packaging command |
+|---|---|
+| `OneIdentity.SafeguardDotNet` | `dotnet pack SafeguardDotNet\SafeguardDotNet.csproj` |
+| `OneIdentity.SafeguardDotNet.BrowserLogin` | `dotnet pack SafeguardDotNet.BrowserLogin\SafeguardDotNet.BrowserLogin.csproj` |
+| `OneIdentity.SafeguardDotNet.PkceNoninteractiveLogin` | `dotnet pack SafeguardDotNet.PkceNoninteractiveLogin\SafeguardDotNet.PkceNoninteractiveLogin.csproj` |
+| `OneIdentity.SafeguardDotNet.GuiLogin` | `nuget pack SafeguardDotNet.GuiLogin\SafeguardDotNet.GuiLogin.nuspec` |
+| symbol packages | `--include-symbols -p:SymbolPackageFormat=snupkg` or `-Symbols -SymbolPackageFormat snupkg` |
+
+### Publication targets
+
+After packing:
+
+- `PublishBuildArtifacts@1` uploads the artifact staging directory as `SafeguardDotNet`
+- `NuGetCommand@2` pushes `*.nupkg` to `https://api.nuget.org/v3/index.json`
+- `GitHubRelease@1` creates a release in `OneIdentity/SafeguardDotNet`
+- GitHub release assets include both `*.nupkg` and `*.snupkg`
+
+## 5. Service connections / secrets required
+
+The release path depends on external connections and secrets that are unavailable in
+normal local development.
+
+### Azure service connections and Key Vaults
+
+| Connection / subscription | Used for | Secrets / resource |
+|---|---|---|
+| `OneIdentity.Infrastructure.SPPCodeSigning` | Access the signing vault | `SPPCodeSigning` Key Vault |
+| `SafeguardOpenSource` | Access release publishing secrets | `SafeguardBuildSecrets` Key Vault |
+
+### Secrets referenced in YAML
+
+| Secret | Purpose |
+|---|---|
+| `SPPCodeSigning-Password` | SSL.com eSignerCKA account password |
+| `SPPCodeSigning-TotpPrivateKey` | SSL.com eSignerCKA TOTP seed/private key |
+| `NugetOrgApiKey` | NuGet.org push credential |
+
+### Other external dependencies
+
+- GitHub service connection: `PangaeaBuild-GitHub`
+- SSL.com signing account user: `ssl.oid.safeguardpp@groups.quest.com`
+- Microsoft-hosted `windows-latest` image with NuGet, MSBuild, and dotnet tooling
+
+### Release caveats
+
+- PR validation intentionally avoids secrets; forked PRs cannot access them.
+- Never assume Key Vault access or signing credentials exist on a developer machine.
+- If a build issue only reproduces with `signFiles=true`, investigate the release job,
+  not the default local build path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,146 +1,81 @@
 # AGENTS.md — SafeguardDotNet
 
-.NET SDK for the One Identity Safeguard Web API. Published as NuGet packages on
-[NuGet.org](https://www.nuget.org/packages/OneIdentity.SafeguardDotNet).
-
-Targets `netstandard2.0`. Root namespace: `OneIdentity.SafeguardDotNet`. Dependencies:
-Newtonsoft.Json, Serilog, Microsoft.AspNetCore.SignalR.Client.
+.NET SDK for the One Identity Safeguard Web API. Targets `netstandard2.0`.
+Root namespace: `OneIdentity.SafeguardDotNet`.
 
 ## Project structure
 
-```
-SafeguardDotNet/
-|-- SafeguardDotNet/                           # Core SDK library (netstandard2.0)
-|   |-- Safeguard.cs                           # Entry point: Connect(), A2A, Event
-|   |-- ISafeguardConnection.cs                # Primary connection interface
-|   |-- SafeguardConnection.cs                 # Base connection implementation
-|   |-- PersistentSafeguardConnection.cs       # Auto-refreshing token decorator
-|   |-- SafeguardDotNetException.cs            # All SDK errors thrown as this type
-|   |-- ExtensionMethods.cs                    # SecureString <-> string conversions
-|   |-- Authentication/                        # IAuthenticationMechanism strategy pattern
-|   |-- Event/                                 # SignalR event listeners
-|   |-- A2A/                                   # Application-to-Application (certificate-only)
-|   `-- Sps/                                   # Safeguard for Privileged Sessions
-|-- SafeguardDotNet.PkceNoninteractiveLogin/   # PKCE login without a browser (MFA support)
-|-- SafeguardDotNet.BrowserLogin/              # PKCE login via system browser
-|-- SafeguardDotNet.GuiLogin/                  # WinForms embedded browser (.NET Framework)
-|-- SafeguardDotNet.LoginCommon/               # Shared login utilities
-|-- Test/                                      # CLI test tools + PowerShell test framework
-|-- Samples/                                   # Example projects
-|-- Directory.Build.props                      # Shared MSBuild props (analyzers, code style)
-|-- build.yml                                  # Azure Pipelines CI/CD definition
-`-- data/                                      # Data files (certificates, etc.)
-```
+- `SafeguardDotNet\` — core SDK: `Safeguard.cs`, connections, auth, events, A2A, SPS
+- `SafeguardDotNet.PkceNoninteractiveLogin\`, `BrowserLogin\`, `GuiLogin\`, `LoginCommon\` — login flows
+- `Test\` — CLI tools plus the PowerShell integration test framework
+- `Samples\` — example integrations
+- `build.yml`, `pipeline-templates\`, `Directory.Build.props` — build, versioning, analyzers
 
 ## Setup and build
 
-| Solution | Purpose | Build tool |
+| Solution | Purpose | Command |
 |---|---|---|
-| `SafeguardDotNet.Core.sln` | SDK + login modules + test tools + samples | `dotnet build` |
-| `SafeguardDotNet.Framework.sln` | GuiLogin + GuiTester (.NET Framework 4.8.1) | `msbuild` |
-| `SafeguardDotNet.sln` | NuGet restore only — not for building |
+| `SafeguardDotNet.Core.sln` | SDK, login modules, test tools, samples | `dotnet build SafeguardDotNet.Core.sln /p:SignFiles=false` |
+| `SafeguardDotNet.Framework.sln` | GuiLogin + GuiTester (.NET Framework 4.8.1) | `msbuild SafeguardDotNet.Framework.sln /p:SignFiles=false` |
+| `SafeguardDotNet\SafeguardDotNet.csproj` | SDK only | `dotnet build SafeguardDotNet\SafeguardDotNet.csproj /p:SignFiles=false` |
 
-```powershell
-# Day-to-day local build (most common)
-dotnet build SafeguardDotNet.Core.sln /p:SignFiles=false
-
-# Build just the SDK
-dotnet build SafeguardDotNet\SafeguardDotNet.csproj /p:SignFiles=false
-```
-
-**Always pass `/p:SignFiles=false` for local builds.** CI uses Azure Key Vault for signing.
-
-The build must complete with **0 errors, 0 warnings**. Strict analysis is enforced via
-`Directory.Build.props` (StyleCop.Analyzers, SonarAnalyzer.CSharp, `EnforceCodeStyleInBuild`).
+Always build with **0 errors and 0 warnings**. Keep `/p:SignFiles=false` for local work;
+CI handles signing.
 
 ## Linting
 
-Linting is integrated into the build via Roslyn analyzers — no separate lint command.
+Linting is part of the build through `Directory.Build.props`; there is no separate command.
+Pay attention to the analyzer set from StyleCop and Sonar, especially:
 
-Key rules enforced:
+- no `#region`
+- one parameter per line when wrapping
+- `s_` for private static fields and `_` for private instance fields
+- no empty `catch` blocks and no single-line statement blocks
 
-| Rule | What it means |
-|------|---------------|
-| SA1124 | No `#region` directives |
-| SA1117 | Split parameters must each be on their own line |
-| SA1306/IDE1006 | Private static fields: `s_` prefix, camelCase |
-| SA1501 | No single-line statement blocks (always use braces) |
-| S2737 | No empty catch clauses |
-| IDE0063 | Prefer simplified `using` declarations |
-| IDE0078 | Prefer pattern matching |
-| IDE0054 | Prefer compound assignment |
-| CA5350 | HMACSHA1 flagged — use `#pragma warning disable` if needed |
+## Testing
+
+Tests are live-appliance based. Use the CLI tools in `Test\` or
+`Test\TestFramework\Invoke-SafeguardTests.ps1`, and read
+`.agents/skills/testing-guide/SKILL.md` before running suites or changing coverage.
 
 ## Code conventions
 
-### Naming
-
-- Private static fields: `s_` prefix (e.g., `s_defaultTimeout`)
-- Private instance fields: `_` prefix (e.g., `_disposed`)
-- Public properties / constants: PascalCase
-
-### SecureString for credentials
-
-All passwords and tokens use `SecureString`. Convert via `ExtensionMethods.cs`:
-`"secret".ToSecureString()` / `secure.ToInsecureString()`. Types holding `SecureString`
-implement `IDisposable`.
-
-### Dispose pattern
-
-Connection classes track `_disposed`. All public instance methods must check and throw
-`ObjectDisposedException` if disposed.
-
-### Error handling
-
-All SDK errors throw `SafeguardDotNetException` with `HttpStatusCode`, `ErrorCode`,
-`ErrorMessage`, and `Response`. Include status code and response body when throwing.
-
-### SSL/TLS
-
-TLS 1.2 enforced on all `HttpClientHandler` instances. `ignoreSsl` bypasses cert validation
-(dev only). `validationCallback` for custom validation. Apply consistently to `HttpClient`
-and SignalR connections. **Never recommend `ignoreSsl` for production.**
-
-### XML documentation
-
-`GenerateDocumentationFile` is enabled. All public types need XML doc comments. The StyleCop
-`xmlHeader` rule is disabled — do not add XML file headers.
-
-### Versioning
-
-Version markers `9999.9999.9999` / `9999.9999.9999.9999` in `.csproj`/`.nuspec` are replaced
-at CI build time by `versionnumber.ps1`. **Do not change these markers manually.**
-
-### NuGet packages
-
-Four packages published per release: `OneIdentity.SafeguardDotNet`,
-`OneIdentity.SafeguardDotNet.BrowserLogin`, `OneIdentity.SafeguardDotNet.PkceNoninteractiveLogin`,
-`OneIdentity.SafeguardDotNet.GuiLogin`. Each includes a `.snupkg` symbols package.
+- Use `SecureString` for passwords, tokens, and secrets; convert with `ExtensionMethods`
+- Dispose objects that hold `SecureString`, certificates, listeners, or connections
+- Public instance methods on disposable connection types must guard `_disposed`
+- Throw `SafeguardDotNetException` for SDK/API failures and preserve status/response details
+- Keep TLS 1.2 behavior and SSL validation handling consistent across `HttpClient` and SignalR
+- `GenerateDocumentationFile` is enabled; public APIs need XML docs, but no XML file headers
 
 ## CI/CD
 
-Azure Pipelines (`build.yml` + `pipeline-templates/`). Two jobs: **PRValidation** (no
-signing) and **BuildAndPublish** (signing + NuGet publish on master/release). Never assume
-Key Vault secrets exist locally.
+See `.agents/skills/build-and-release/SKILL.md` for pipeline stages, signing,
+packaging, publishing, releases, and required service connections.
 
 ## Security
 
-- Never commit secrets, tokens, or credentials
-- `SecureString` data must not be logged or serialized
-- Test credentials only in runner parameters, never hardcoded
-- `ignoreSsl` / `-x` is dev-only — always warn about production use
+- Never commit credentials, tokens, or certificate material
+- Never log or serialize secret `SecureString` values
+- Test credentials belong in runner parameters, not source files
+- `ignoreSsl` / `-x` is for dev/test only
 
-## Keeping this file current
+## Versioning
 
-After completing tasks, suggest updates for new pitfalls, test suites, patterns, stale
-information, or corrections. Skills (below) should be updated alongside this file.
+- `Safeguard.DefaultApiVersion` is `4`; use `apiVersion: 3` only for legacy support
+- Keep the `9999.9999.9999` and `9999.9999.9999.9999` placeholders in project metadata
+- `pipeline-templates\versionnumber.ps1` stamps tag builds (`v<major>.<minor>.<patch>`) and prerelease builds from `semanticVersion`
 
 ## On-demand skills
 
-The following skills contain deeper reference material loaded only when relevant.
-Read the `SKILL.md` when your current task matches the trigger.
-
 | Skill | When to read | File |
-|-------|-------------|------|
-| Testing Guide | Running tests, writing tests, test failures, live appliance setup | `.agents/skills/testing-guide/SKILL.md` |
-| Architecture Deep Dive | SDK internals, auth mechanisms, PKCE/rSTS, events, A2A, SPS, Swagger | `.agents/skills/architecture-deep-dive/SKILL.md` |
+|---|---|---|
+| Architecture | SDK internals, auth, PKCE/rSTS, events, management, SPS | `.agents/skills/architecture/SKILL.md` |
+| API Patterns | Standard REST calls, service selection, CRUD, headers, Swagger | `.agents/skills/api-patterns/SKILL.md` |
+| A2A Workflow | Certificate-based A2A setup, retrieval, brokering, listeners | `.agents/skills/a2a-workflow/SKILL.md` |
+| Build and Release | Azure Pipelines flow, version stamping, signing, publishing | `.agents/skills/build-and-release/SKILL.md` |
+| Testing Guide | Live appliance setup, suites, failures, test authoring | `.agents/skills/testing-guide/SKILL.md` |
+
+## Keeping this file current
+
+Keep this file short, and move deep workflow/reference material into skills. Update the
+routing table whenever skills are added, removed, or renamed.


### PR DESCRIPTION
Implements the skills harmonization plan:

- Renamed `architecture-deep-dive` → `architecture`
- Created `api-patterns` skill (ISafeguardConnection, InvokeMethod, services)
- Created `build-and-release` skill (extracted CI/CD from AGENTS.md)
- Created `a2a-workflow` skill (ISafeguardA2AContext, credential retrieval, events)
- Updated AGENTS.md to standard template

Part of cross-repo effort to standardize agent skills across all Safeguard SDK repositories.