### PR TITLE
docs: correct README API examples to match shipped code

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ var userJson = connection.InvokeMethod(Service.Core, Method.Post, "Users",
     }));
 var userObj = JsonConvert.DeserializeAnonymousType(userJson, new { Id = 0 });
 connection.InvokeMethod(Service.Core, Method.Put, $"Users/{userObj.Id}/Password",
-    JsonConvert.SerializeObject("MyNewUser123");
+    JsonConvert.SerializeObject("MyNewUser123"));
 ```
 
 ## Using SafeguardDotNet from a New Visual Studio Code Project

--- a/SafeguardDotNet.BrowserLogin/README.md
+++ b/SafeguardDotNet.BrowserLogin/README.md
@@ -41,23 +41,24 @@ using OneIdentity.SafeguardDotNet;
 using OneIdentity.SafeguardDotNet.BrowserLogin;
 
 // Authenticate user via browser
-var connection = Safeguard.ConnectBrowser("safeguard.company.com");
+var connection = DefaultBrowserLogin.Connect("safeguard.company.com");
 
 // Use the authenticated connection
 string userData = connection.InvokeMethod(Service.Core, Method.Get, "Me");
 Console.WriteLine($"Logged in as: {userData}");
 ```
 
-### With Specific Authentication Provider
+### Pre-fill the username
 
 ```csharp
-var connection = DefaultBrowserLogin.Connect("myspp.petrsnd.test", ignoreSsl: false);
+var connection = DefaultBrowserLogin.Connect(
+    "safeguard.company.com", username: "Admin", ignoreSsl: false);
 ```
 
 ### Advanced Options
 
 ```csharp
-// Configure an alternate listing port (default: 8400 [same as Microsoft])
+// Configure an alternate listener port (default: 8400)
 var connection = DefaultBrowserLogin.Connect("safeguard.company.com", port: 8080);
 ```
 

--- a/SafeguardDotNet.DeviceCodeLogin/README.md
+++ b/SafeguardDotNet.DeviceCodeLogin/README.md
@@ -75,7 +75,7 @@ using var connection = await DeviceCodeLogin.ConnectAsync(
 | Credentials in Code | No | Yes (username/password) | No |
 | SSO/MFA Support | Yes | Limited | Yes |
 | Headless Compatible | No | Yes | Yes |
-| Async API | No | No | Yes |
+| Async API | Yes | Yes | Yes |
 | Use Case | Desktop apps | Automation with known creds | Headless with user auth |
 
 ## Configuration

--- a/SafeguardDotNet.GuiLogin/README.md
+++ b/SafeguardDotNet.GuiLogin/README.md
@@ -58,7 +58,7 @@ Console.WriteLine($"Logged in as: {userData}");
 
 ## How It Works
 
-1. **Show Dialog** - Application calls `Safeguard.ConnectGui()` which displays WinForms dialog
+1. **Show Dialog** - Application calls `LoginWindow.Connect()` which displays a WinForms dialog
 2. **Embedded Browser** - Dialog contains WebView2 control showing Safeguard login page
 3. **User Authenticates** - User logs in through their chosen identity provider
 4. **Capture Token** - Dialog captures OAuth token from redirect

--- a/SafeguardDotNet.PkceNoninteractiveLogin/README.md
+++ b/SafeguardDotNet.PkceNoninteractiveLogin/README.md
@@ -20,41 +20,65 @@ This library provides OAuth2/PKCE authentication to Safeguard by allowing applic
 
 ## Usage Example
 
+The library drives the OAuth2/PKCE authorization-code flow internally by
+posting directly to the rSTS login endpoints — no browser, no TCP listener,
+and no caller-supplied authorization code are required. The caller supplies
+the appliance address and credentials; everything else (code verifier/
+challenge generation, authorization, code redemption, token exchange) is
+handled by `Connect` / `ConnectAsync`.
+
 ```csharp
+using System.Security;
+using OneIdentity.SafeguardDotNet;
 using OneIdentity.SafeguardDotNet.PkceNoninteractiveLogin;
 
-// Step 1: Generate PKCE parameters
-var codeVerifier = PkceNoninteractiveLogin.GenerateCodeVerifier();
-var codeChallenge = PkceNoninteractiveLogin.GenerateCodeChallenge(codeVerifier);
+SecureString password = GetPasswordSecurely();
 
-// Step 2: Build authorization URL
-var authUrl = PkceNoninteractiveLogin.BuildAuthorizationUrl(
-    "safeguard.example.com",
-    codeChallenge,
-    username: "admin");
+using var connection = PkceNoninteractiveLogin.Connect(
+    appliance: "safeguard.example.com",
+    provider:  "local",
+    username:  "Admin",
+    password:  password,
+    ignoreSsl: false);
 
-// Step 3: Your custom code to authenticate and obtain authorization code
-// (e.g., using Selenium, Playwright, or other automation tools)
-var authorizationCode = YourCustomAuthenticationMethod(authUrl);
+var me = connection.InvokeMethod(Service.Core, Method.Get, "Me");
+```
 
-// Step 4: Connect to Safeguard
-var connection = PkceNoninteractiveLogin.Connect(
-    "safeguard.example.com",
-    authorizationCode,
-    codeVerifier);
+### Multi-factor authentication
 
-// Step 5: Use the connection
-var userData = connection.InvokeMethod(Service.Core, Method.Get, "Me");
+If the identity provider requires a second factor (TOTP, RADIUS, etc.), pass
+the one-time code as `secondaryPassword`:
+
+```csharp
+SecureString password = GetPasswordSecurely();
+SecureString totp = GetOneTimeCodeSecurely();
+
+using var connection = PkceNoninteractiveLogin.Connect(
+    "safeguard.example.com", "local", "Admin", password, totp);
+```
+
+### Async with cancellation
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+SecureString password = GetPasswordSecurely();
+
+using var connection = await PkceNoninteractiveLogin.ConnectAsync(
+    "safeguard.example.com", "local", "Admin", password,
+    secondaryPassword: null,
+    apiVersion: Safeguard.DefaultApiVersion,
+    ignoreSsl: false,
+    cancellationToken: cts.Token);
 ```
 
 ## Comparison with BrowserLogin
 
 | Feature | BrowserLogin | PkceNoninteractiveLogin |
 |---------|-------------|-------------------------|
-| Browser Launch | Automatic | Manual (caller controlled) |
-| TCP Listener | Built-in | Not included |
-| Authorization Code | Captured automatically | Must be obtained by caller |
-| Use Case | Interactive desktop apps | Automated testing, custom flows |
+| Browser Launch | Automatic | None — flow is driven over HTTP |
+| TCP Listener | Built-in | Not needed |
+| Credentials | Entered in browser by user | Supplied by caller (username/password, optional MFA code) |
+| Use Case | Interactive desktop apps | Automated testing, CI/CD, headless integrations |
 
 ## Dependencies
 

--- a/build.yml
+++ b/build.yml
@@ -12,7 +12,6 @@ trigger:
     - 'v*'
   paths:
     exclude:
-    - '*.md'
     - '**/*.md'
     - LICENSE
     - docs/
@@ -26,7 +25,6 @@ pr:
     - release-*
   paths:
     exclude:
-    - '*.md'
     - '**/*.md'
     - LICENSE
     - docs/

--- a/build.yml
+++ b/build.yml
@@ -12,6 +12,7 @@ trigger:
     - 'v*'
   paths:
     exclude:
+    - '*.md'
     - '**/*.md'
     - LICENSE
     - docs/
@@ -25,6 +26,7 @@ pr:
     - release-*
   paths:
     exclude:
+    - '*.md'
     - '**/*.md'
     - LICENSE
     - docs/


### PR DESCRIPTION
Several READMEs documented APIs that don't exist in the shipped SDK. Fixed by grounding examples in the actual public surface.

- `SafeguardDotNet.PkceNoninteractiveLogin/README.md` — Replaced the fictional `GenerateCodeVerifier` / `GenerateCodeChallenge` / `BuildAuthorizationUrl` / `YourCustomAuthenticationMethod` flow with the real `PkceNoninteractiveLogin.Connect` / `ConnectAsync` overloads (the class drives the rSTS PKCE flow internally).
- `SafeguardDotNet.BrowserLogin/README.md` — `Safeguard.ConnectBrowser(...)` does not exist; corrected to `DefaultBrowserLogin.Connect(...)`.
- `SafeguardDotNet.GuiLogin/README.md` — `Safeguard.ConnectGui()` does not exist; corrected to `LoginWindow.Connect()`.
- `SafeguardDotNet.DeviceCodeLogin/README.md` — Comparison table claimed PkceNoninteractiveLogin has no async API; it does (`ConnectAsync`).
- `README.md` — Fixed missing closing paren in the `Create a New User` snippet.

No code changes.