### PR TITLE
Document 9.0 changes (System.Text.Json => AOT) and tidy serializer context

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ provides an opportunity for reacting programmatically to any data modification
 in Safeguard. Events are also supported for access request workflow and for
 A2A password changes.
 
-SafeguardDotNet uses RestSharp and Json.NET to call the Safeguard API. It
-includes calls to Serilog, and if your calling application provides a sink you
-will get log information automatically.
+SafeguardDotNet uses `HttpClient` and `System.Text.Json` (with source-generated
+serializers for trim/AOT friendliness) to call the Safeguard API. It includes
+calls to Serilog, and if your calling application provides a sink you will get
+log information automatically.
 
 ## Logging & diagnostics
 

--- a/README.md
+++ b/README.md
@@ -387,9 +387,11 @@ Console.WriteLine(connection.InvokeMethod(Service.Notification, Method.Get, "Sta
 #### Create a New Linux Asset
 
 ```C#
+using System.Text.Json;
+
 // Assume connection is already made
 var json = connection.InvokeMethod(Service.Core, Method.Post, "Assets",
-    JsonConvert.SerializeObject(new {
+    JsonSerializer.Serialize(new {
         Name = "linux.blue.vas",
         NetworkAddress = "linux.blue.vas",
         Description = "A new linux asset",
@@ -402,15 +404,18 @@ Console.WriteLine(json);
 #### Create a New User and Set the Password
 
 ```C#
+using System.Text.Json;
+
 // Assume connection is already made
 var userJson = connection.InvokeMethod(Service.Core, Method.Post, "Users",
-    JsonConvert.SerializeObject(new {
+    JsonSerializer.Serialize(new {
         PrimaryAuthenticationProviderId = -1,
         UserName = "MyNewUser"
     }));
-var userObj = JsonConvert.DeserializeAnonymousType(userJson, new { Id = 0 });
-connection.InvokeMethod(Service.Core, Method.Put, $"Users/{userObj.Id}/Password",
-    JsonConvert.SerializeObject("MyNewUser123"));
+using var userDoc = JsonDocument.Parse(userJson);
+var userId = userDoc.RootElement.GetProperty("Id").GetInt32();
+connection.InvokeMethod(Service.Core, Method.Put, $"Users/{userId}/Password",
+    JsonSerializer.Serialize("MyNewUser123"));
 ```
 
 ## Using SafeguardDotNet from a New Visual Studio Code Project

--- a/SafeguardDotNet/README.md
+++ b/SafeguardDotNet/README.md
@@ -34,6 +34,12 @@ SafeguardDotNet provides a comprehensive .NET SDK for interacting with the One I
   - Built-in logging via Serilog integration
   - Comprehensive error handling with `SafeguardDotNetException`
 
+- **Modern Serialization (v9.0+)**
+  - `System.Text.Json` with source-generated serializers
+  - Trim- and Native-AOT-friendly: usable from `PublishAot=true` consumers
+  - Reduced dependency footprint — no Newtonsoft.Json, no RestSharp,
+    no Microsoft.AspNet.WebApi.Client
+
 ## Quick Start
 
 ### Installation
@@ -103,7 +109,33 @@ Safeguard 7.X+ hosts both v3 and v4 APIs simultaneously.
 
 ## Target Framework
 
-- **netstandard2.0** - Compatible with .NET Framework 4.6.1+, .NET Core 2.0+, .NET 5+, and .NET 6+
+- **netstandard2.0** — runs on .NET Framework 4.6.1+, .NET Core 2.0+, .NET 5/6/8/10+
+- Annotated for **trimming and Native AOT** so consumers publishing with
+  `PublishTrimmed=true` or `PublishAot=true` get a clean build with no
+  `IL2026` / `IL3050` warnings from the SDK
+
+## Upgrading to 9.0
+
+Version 9.0 replaces Newtonsoft.Json with `System.Text.Json` throughout the
+SDK. Most callers are unaffected, but a few public surface changes are
+source-breaking:
+
+- `A2ARegistration.Id` is now `int` (was `string`) to match the API contract.
+- `Safeguard.PostLoginResponseAsync` now returns `string` instead of
+  `Newtonsoft.Json.Linq.JObject`. This is an rSTS plumbing helper used
+  internally by the login modules — most consumers go through
+  `Safeguard.Connect(...)` or `ExchangeRstsTokenForConnectionAsync` and are
+  unaffected. Direct callers can parse the response with
+  `JsonDocument.Parse(...)` or a typed deserialization of their choice.
+- `Newtonsoft.Json` and `Microsoft.AspNet.WebApi.Client` are no longer
+  transitive dependencies — if your project relied on them implicitly, add an
+  explicit `PackageReference`.
+
+Bug fixes shipped alongside the migration:
+
+- `UtcDateTimeJsonConverter` now returns `DateTime` values in UTC.
+- `CustomTimeSpanJsonConverter` correctly parses the appliance's `D:H:M`
+  `TimeSpan` format.
 
 ## Documentation
 

--- a/SafeguardDotNet/Serialization/SafeguardJsonContext.cs
+++ b/SafeguardDotNet/Serialization/SafeguardJsonContext.cs
@@ -13,19 +13,27 @@ using OneIdentity.SafeguardDotNet.A2A;
 /// Guarantees AOT-compatible, reflection-free serialization at compile time.
 /// </summary>
 [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
-[JsonSerializable(typeof(BrokeredAccessRequest))]
+
+// BCL / framework types
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(JsonElement))]
+
+// Authentication / connection DTOs
+[JsonSerializable(typeof(LoginResponse))]
+[JsonSerializable(typeof(JoinRequest))]
+
+// A2A DTOs
+[JsonSerializable(typeof(A2ARegistration))]
 [JsonSerializable(typeof(A2ARetrievableAccount))]
 [JsonSerializable(typeof(ApiKeySecret))]
-[JsonSerializable(typeof(LoginResponse))]
-[JsonSerializable(typeof(Dictionary<string, string>))]
-[JsonSerializable(typeof(JoinRequest))]
+[JsonSerializable(typeof(BrokeredAccessRequest))]
 [JsonSerializable(typeof(SshKey))]
-[JsonSerializable(typeof(A2ARegistration))]
+
+// A2A list shapes
 [JsonSerializable(typeof(List<A2ARegistration>))]
 [JsonSerializable(typeof(List<A2ARetrievableAccount>))]
 [JsonSerializable(typeof(List<ApiKeySecret>))]
-[JsonSerializable(typeof(string))]
-[JsonSerializable(typeof(JsonElement))]
 internal partial class SafeguardJsonContext : JsonSerializerContext
 {
 }


### PR DESCRIPTION
Documentation pass to make sure 9.0 consumers see the changes that motivated
 the major version bump.
 
 - Top-level README: replace the stale "RestSharp and Json.NET" intro and
   rewrite the API examples to use System.Text.Json so they compile against
   9.0 out of the box.
 - NuGet README (SafeguardDotNet/README.md): add a "Modern Serialization"
   feature bullet, refresh the target framework section to call out trim and
   Native AOT support, and add an "Upgrading to 9.0" section listing the
   source-breaking changes (A2ARegistration.Id, PostLoginResponseAsync,
   removed transitive dependencies) and the converter bug fixes.
 - SafeguardJsonContext: group [JsonSerializable] registrations by source
   (BCL, auth/connection, A2A, A2A lists) and sort within each group.

No behavior change.
